### PR TITLE
feat: pre-register route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "source-map-support": "0.5.21",
         "swagger-ui-express": "4.6.3",
         "twitter": "1.7.1",
-        "typeorm": "0.3.16"
+        "typeorm": "0.3.16",
+        "validation-br": "^1.4.4"
       },
       "devDependencies": {
         "@nestjs/cli": "9.5.0",
@@ -19542,6 +19543,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/validation-br": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/validation-br/-/validation-br-1.4.4.tgz",
+      "integrity": "sha512-7CPzlwWQO3coCMciH4GbyMBK3h1tNG+ZrY6R97IyUZC1WS0GCYlH2j6pQCIdhZdZOpe/nwv7px1+F2k0RWvaWQ=="
     },
     "node_modules/validator": {
       "version": "13.7.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "source-map-support": "0.5.21",
     "swagger-ui-express": "4.6.3",
     "twitter": "1.7.1",
-    "typeorm": "0.3.16"
+    "typeorm": "0.3.16",
+    "validation-br": "^1.4.4"
   },
   "devDependencies": {
     "@nestjs/cli": "9.5.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,8 @@ import { HomeModule } from './home/home.module';
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { AllConfigType } from './config/config.type';
 import { InfoModule } from './info/info.module';
+import { AuthLicenseeModule } from './auth-licensee/auth-licensee.module';
+import { SgtuModule } from './sgtu/sgtu.module';
 
 @Module({
   imports: [
@@ -86,6 +88,8 @@ import { InfoModule } from './info/info.module';
     MailModule,
     HomeModule,
     InfoModule,
+    AuthLicenseeModule,
+    SgtuModule,
   ],
 })
 export class AppModule {}

--- a/src/auth-licensee/auth-licensee.controller.spec.ts
+++ b/src/auth-licensee/auth-licensee.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthLicenseeController } from './auth-licensee.controller';
+
+describe('AuthLicenseeController', () => {
+  let controller: AuthLicenseeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthLicenseeController],
+    }).compile();
+
+    controller = module.get<AuthLicenseeController>(AuthLicenseeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/auth-licensee/auth-licensee.controller.ts
+++ b/src/auth-licensee/auth-licensee.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SgtuInterface } from 'src/sgtu/interfaces/sgtu.interface';
+import { AuthPreRegisterLicenseeDto } from './dto/auth-pre-register-licensee.dto';
+import { AuthLicenseeService } from './auth-licensee.service';
+
+@ApiTags('Auth')
+@Controller({
+  path: 'auth/licensee',
+  version: '1',
+})
+export class AuthLicenseeController {
+  constructor(private service: AuthLicenseeService) {}
+
+  @Post('pre-register')
+  @HttpCode(HttpStatus.OK)
+  async preRegister(
+    @Body() loginDto: AuthPreRegisterLicenseeDto,
+  ): Promise<SgtuInterface> {
+    const profile = await this.service.getProfileByCredentials(loginDto);
+    return profile;
+  }
+}

--- a/src/auth-licensee/auth-licensee.module.ts
+++ b/src/auth-licensee/auth-licensee.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuthLicenseeController } from './auth-licensee.controller';
+import { AuthLicenseeService } from './auth-licensee.service';
+import { SgtuModule } from 'src/sgtu/sgtu.module';
+
+@Module({
+  imports: [SgtuModule],
+  controllers: [AuthLicenseeController],
+  providers: [AuthLicenseeService],
+})
+export class AuthLicenseeModule {}

--- a/src/auth-licensee/auth-licensee.service.spec.ts
+++ b/src/auth-licensee/auth-licensee.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthLicenseeService } from './auth-licensee.service';
+
+describe('AuthLicenseeService', () => {
+  let service: AuthLicenseeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthLicenseeService],
+    }).compile();
+
+    service = module.get<AuthLicenseeService>(AuthLicenseeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/auth-licensee/auth-licensee.service.ts
+++ b/src/auth-licensee/auth-licensee.service.ts
@@ -1,0 +1,34 @@
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { SgtuInterface } from 'src/sgtu/interfaces/sgtu.interface';
+import { SgtuService } from 'src/sgtu/sgtu.service';
+import { AuthPreRegisterLicenseeDto } from './dto/auth-pre-register-licensee.dto';
+
+@Injectable()
+export class AuthLicenseeService {
+  @Inject(SgtuService)
+  private readonly sgtuService: SgtuService;
+
+  public async getProfileByCredentials(
+    loginDto: AuthPreRegisterLicenseeDto,
+  ): Promise<SgtuInterface> {
+    // TODO: SGTU fetch instead of sgtuResponseMockup
+
+    const sgtuResponse: SgtuInterface =
+      await this.sgtuService.getSgtuProfileByLicensee(loginDto.licensee);
+
+    // Validate if CPF/RG exists in  response
+    if (!(loginDto.cpfCnpj === sgtuResponse.cpfCnpj)) {
+      throw new HttpException(
+        {
+          status: HttpStatus.UNPROCESSABLE_ENTITY,
+          errors: {
+            cpfCnpj: 'cpfCnpjDoesNotMatch',
+          },
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    return sgtuResponse;
+  }
+}

--- a/src/auth-licensee/dto/auth-pre-register-licensee.dto.ts
+++ b/src/auth-licensee/dto/auth-pre-register-licensee.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { IsCpfCnpj } from '../validators/is-cpf-cnpj.validator';
+
+export class AuthPreRegisterLicenseeDto {
+  @ApiProperty({ example: 'P1234' })
+  @IsNotEmpty()
+  licensee: string;
+
+  @ApiProperty({ example: '79858972679' })
+  @IsNotEmpty()
+  @IsCpfCnpj()
+  cpfCnpj: string;
+}

--- a/src/auth-licensee/validators/is-cpf-cnpj.validator.ts
+++ b/src/auth-licensee/validators/is-cpf-cnpj.validator.ts
@@ -1,0 +1,29 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { isCPF, isCNPJ } from 'validation-br';
+
+@ValidatorConstraint({ async: false })
+export class IsCnpjConstraint implements ValidatorConstraintInterface {
+  validate(value: any) {
+    return isCPF(value) || isCNPJ(value);
+  }
+  defaultMessage() {
+    return 'invalidCpfCnpj';
+  }
+}
+
+export function IsCpfCnpj(validationOptions?: ValidationOptions) {
+  return function (object: any, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsCnpjConstraint,
+    });
+  };
+}

--- a/src/sgtu/interfaces/sgtu.interface.ts
+++ b/src/sgtu/interfaces/sgtu.interface.ts
@@ -1,0 +1,9 @@
+export interface SgtuInterface {
+  id?: string;
+  cpfCnpj?: string;
+  rg?: string;
+  licensee?: string;
+  name?: string;
+  plate?: string;
+  phone?: string;
+}

--- a/src/sgtu/sgtu.module.ts
+++ b/src/sgtu/sgtu.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SgtuService } from './sgtu.service';
+
+@Module({
+  providers: [SgtuService],
+  exports: [SgtuService],
+})
+export class SgtuModule {}

--- a/src/sgtu/sgtu.service.spec.ts
+++ b/src/sgtu/sgtu.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SgtuService } from './sgtu.service';
+
+describe('SgtuService', () => {
+  let service: SgtuService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SgtuService],
+    }).compile();
+
+    service = module.get<SgtuService>(SgtuService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/sgtu/sgtu.service.ts
+++ b/src/sgtu/sgtu.service.ts
@@ -1,0 +1,64 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { SgtuInterface } from './interfaces/sgtu.interface';
+
+@Injectable()
+export class SgtuService {
+  private sgtuResponseMockup = JSON.stringify({
+    data: [
+      {
+        id: '1',
+        cpf: '79858972679',
+        rg: '987654321',
+        autorizacao: 'P1234',
+        nome: 'Usuário 1',
+        placa: 'ABC1234',
+        telefone: '999999999',
+      },
+      {
+        id: '2',
+        cpf: '98765432100',
+        rg: '123456789',
+        autorizacao: 'D4567',
+        nome: 'Usuário 2',
+        placa: 'DEF4567',
+        telefone: '888888888',
+      },
+    ],
+  });
+
+  public async getSgtuProfileByLicensee(
+    licensee: string,
+  ): Promise<SgtuInterface> {
+    // TODO: fetch instead of mockup
+
+    const sgtuResponseObject = await JSON.parse(this.sgtuResponseMockup);
+    const sgtuResponse: SgtuInterface[] = sgtuResponseObject.data.map(
+      (item) => ({
+        cpfCnpj: item.cpf,
+        rg: item.rg,
+        licensee: item.autorizacao,
+        name: item.nome,
+        plate: item.placa,
+        phone: item.telefone,
+      }),
+    );
+
+    const filteredData = sgtuResponse.filter(
+      (item) => item.licensee === licensee,
+    );
+
+    if (filteredData.length === 1) {
+      return filteredData[0];
+    } else {
+      throw new HttpException(
+        {
+          status: HttpStatus.UNPROCESSABLE_ENTITY,
+          errors: {
+            licensee: 'licenseeProfileNotFound',
+          },
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+  }
+}


### PR DESCRIPTION
# Mudanças
- 🎁 Nova rota para o app realizar o pré-cadastro

# Detalhes

Mudanças relevantes:
- Novo módulo responsável por obter dados do SGTU
- Novo módulo responsável por realizar o pré-cadastro

SGTU:
- O módulo utiliza um dados simulados enquanto não é possível obter o serviço diretamente.

Pré-cadsatro:
- Além de validar o CPF com os dados do SGTU, é feita uma validação se os campos de cpf/cnpj são válidos.
