### PR TITLE
fix: use separated envs instead of json

### DIFF
--- a/src/bigquery/bigquery.service.ts
+++ b/src/bigquery/bigquery.service.ts
@@ -13,10 +13,48 @@ export class BigqueryService {
   private logger: Logger = new Logger('BigqueryService', { timestamp: true });
 
   constructor(private configService: ConfigService<AllConfigType>) {
-    const jsonCredentials = () =>
-      this.configService.getOrThrow('google.clientApiJson', { infer: true });
+    const jsonCredentials = () => ({
+      type: this.configService.getOrThrow('google.clientApiType', {
+        infer: true,
+      }),
+      project_id: this.configService.getOrThrow('google.clientApiProjectId', {
+        infer: true,
+      }),
+      private_key_id: this.configService.getOrThrow(
+        'google.clientApiPrivateKeyId',
+        { infer: true },
+      ),
+      private_key: this.configService.getOrThrow('google.clientApiPrivateKey', {
+        infer: true,
+      }),
+      client_email: this.configService.getOrThrow(
+        'google.clientApiClientEmail',
+        { infer: true },
+      ),
+      client_id: this.configService.getOrThrow('google.clientApiClientId', {
+        infer: true,
+      }),
+      auth_uri: this.configService.getOrThrow('google.clientApiAuthUri', {
+        infer: true,
+      }),
+      token_uri: this.configService.getOrThrow('google.clientApiTokenUri', {
+        infer: true,
+      }),
+      auth_provider_x509_cert_url: this.configService.getOrThrow(
+        'google.clientApiAuthProviderX509CertUrl',
+        { infer: true },
+      ),
+      client_x509_cert_url: this.configService.getOrThrow(
+        'google.clientApiClientX509CertUrl',
+        { infer: true },
+      ),
+      universe_domain: this.configService.getOrThrow(
+        'google.clientApiUniverseDomain',
+        { infer: true },
+      ),
+    });
     this.bigQueryInstances.smtr = new BigQuery({
-      credentials: JSON.parse(jsonCredentials()),
+      credentials: jsonCredentials(),
     });
   }
 

--- a/src/config/config.type.ts
+++ b/src/config/config.type.ts
@@ -54,7 +54,17 @@ export type FileConfig = {
 export type GoogleConfig = {
   clientId?: string;
   clientSecret?: string;
-  clientApiJson?: string;
+  clientApiType?: string;
+  clientApiProjectId?: string;
+  clientApiPrivateKeyId?: string;
+  clientApiPrivateKey?: string;
+  clientApiClientEmail?: string;
+  clientApiClientId?: string;
+  clientApiAuthUri?: string;
+  clientApiTokenUri?: string;
+  clientApiAuthProviderX509CertUrl?: string;
+  clientApiClientX509CertUrl?: string;
+  clientApiUniverseDomain?: string;
 };
 
 export type MailConfig = {

--- a/src/config/google.config.ts
+++ b/src/config/google.config.ts
@@ -1,6 +1,6 @@
 import { registerAs } from '@nestjs/config';
 import { GoogleConfig } from './config.type';
-import { IsJSON, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import validateConfig from 'src/utils/validate-config';
 
 class EnvironmentVariablesValidator {
@@ -12,8 +12,38 @@ class EnvironmentVariablesValidator {
   @IsString()
   GOOGLE_CLIENT_SECRET: string;
 
-  @IsJSON()
-  GOOGLE_CLIENT_API_JSON: string;
+  @IsString()
+  GOOGLE_CLIENT_API_TYPE: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_PROJECT_ID: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_PRIVATE_KEY_ID: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_PRIVATE_KEY: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_CLIENT_EMAIL: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_CLIENT_ID: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_AUTH_URI: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_TOKEN_URI: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_AUTH_PROVIDER_X509_CERT_URL: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_CLIENT_X509_CERT_URL: string;
+
+  @IsString()
+  GOOGLE_CLIENT_API_UNIVERSE_DOMAIN: string;
 }
 
 export default registerAs<GoogleConfig>('google', () => {
@@ -22,6 +52,18 @@ export default registerAs<GoogleConfig>('google', () => {
   return {
     clientId: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    clientApiJson: process.env.GOOGLE_CLIENT_API_JSON,
+    clientApiType: process.env.GOOGLE_CLIENT_API_TYPE,
+    clientApiProjectId: process.env.GOOGLE_CLIENT_API_PROJECT_ID,
+    clientApiPrivateKeyId: process.env.GOOGLE_CLIENT_API_PRIVATE_KEY_ID,
+    clientApiPrivateKey: process.env.GOOGLE_CLIENT_API_PRIVATE_KEY,
+    clientApiClientEmail: process.env.GOOGLE_CLIENT_API_CLIENT_EMAIL,
+    clientApiClientId: process.env.GOOGLE_CLIENT_API_CLIENT_ID,
+    clientApiAuthUri: process.env.GOOGLE_CLIENT_API_AUTH_URI,
+    clientApiTokenUri: process.env.GOOGLE_CLIENT_API_TOKEN_URI,
+    clientApiAuthProviderX509CertUrl:
+      process.env.GOOGLE_CLIENT_API_AUTH_PROVIDER_X509_CERT_URL,
+    clientApiClientX509CertUrl:
+      process.env.GOOGLE_CLIENT_API_CLIENT_X509_CERT_URL,
+    clientApiUniverseDomain: process.env.GOOGLE_CLIENT_API_UNIVERSE_DOMAIN,
   };
 });


### PR DESCRIPTION
## ⚠️ Mudanças nos envs

O env `GOOGLE_CLIENT_API_JSON` não é mais usado.

Os novos envs para logar no bigquery são estes:
```
GOOGLE_CLIENT_API_TYPE=
GOOGLE_CLIENT_API_PROJECT_ID=
GOOGLE_CLIENT_API_PRIVATE_KEY_ID=
GOOGLE_CLIENT_API_PRIVATE_KEY=
GOOGLE_CLIENT_API_CLIENT_EMAIL=
GOOGLE_CLIENT_API_CLIENT_ID=
GOOGLE_CLIENT_API_AUTH_URI=
GOOGLE_CLIENT_API_TOKEN_URI=
GOOGLE_CLIENT_API_AUTH_PROVIDER_X509_CERT_URL=
GOOGLE_CLIENT_API_CLIENT_X509_CERT_URL=
GOOGLE_CLIENT_API_UNIVERSE_DOMAIN=
```