### PR TITLE
Atualizar visual do email de redefinir senha e correções

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -271,7 +271,7 @@ export class AuthService {
         mailData,
       );
       if (mailResponse.mailSentInfo.success === true) {
-        userMailHistory.setInviteStatus(InviteStatusEnum.queued);
+        userMailHistory.setInviteStatus(InviteStatusEnum.sent);
         userMailHistory.sentAt = new Date(Date.now());
         await this.mailHistoryService.update(
           userMailHistory.id,

--- a/src/mail/mail-templates/reset-password.hbs
+++ b/src/mail/mail-templates/reset-password.hbs
@@ -9,27 +9,27 @@
 
 <body style="margin:0;font-family:arial">
     <table style="border:0;width:100%">
-        <tr style="background:#eeeeee">
-            <td style="padding:20px;color:#808080;text-align:center;font-size:40px;font-weight:600">
-                {{app_name}}
+        <tr style="background:rgba(150,150,150,0.2)">
+            <td style="padding:20px;color:#004a80;text-align:left;font-size:30px;font-weight:600;">
+                <img src="{{logoSrc}}" alt="{{logoAlt}}" style="max-width: 300px; max-height: 86px;">
             </td>
         </tr>
         <tr>
             <td style="padding:20px;color:#808080;font-size:16px;font-weight:100">
-                {{text1}}<br>
-                {{text2}}<br>
-                {{text3}}
+                <p>
+                {{bodyText}}
+                </p>
             </td>
         </tr>
         <tr>
             <td style="text-align:center">
                 <a href="{{url}}"
-                    style="display:inline-block;padding:20px;background:#00838f;text-decoration:none;color:#ffffff">{{actionTitle}}</a>
+                    style="display:inline-block;padding:20px;background:#00838f;text-decoration:none;color:#ffffff">{{buttonText}}</a>
             </td>
         </tr>
         <tr>
             <td style="padding:20px;color:#808080;font-size:16px;font-weight:100">
-                {{text4}}
+                {{footerText}}
             </td>
         </tr>
     </table>


### PR DESCRIPTION
## Mudanças
- chore: Visual do email de refedinir senha segue o padrão usado no email de finalizar cadastro.
- fix: Endpoint `email/resend` não atualiza status do email de "Na fila" para "Enviado".