### PR TITLE
fix: Sempre mostrar próxima sexta se for no mesmo mês, e testes

### DIFF
--- a/src/bank-statements/bank-statements.service.ts
+++ b/src/bank-statements/bank-statements.service.ts
@@ -67,11 +67,13 @@ export class BankStatementsService {
     const amountSum = Number(
       treatedData.reduce((sum, item) => sum + item.amount, 0).toFixed(2),
     );
+    const ticketCount = insertedData.countSum;
 
     return {
       amountSum,
       todaySum,
       count: treatedData.length,
+      ticketCount,
       data: treatedData,
     };
   }
@@ -85,6 +87,7 @@ export class BankStatementsService {
     statements: ICoreBankStatements[];
     todaySum: number;
     allSum: number;
+    countSum: number;
   }> {
     const statementsDates = getPaymentDates(
       'ticket-revenues',
@@ -106,7 +109,7 @@ export class BankStatementsService {
     );
 
     const todaySum = revenuesResponse.todaySum;
-    let sumAll = 0;
+    let allSum = 0;
     const newStatements: ICoreBankStatements[] = [];
 
     // for each week in month (bank-statements)
@@ -130,15 +133,10 @@ export class BankStatementsService {
         ...statement,
         amount: newAmount,
       });
-      sumAll += newAmount;
+      allSum += newAmount;
     }
-    console.log({
-      message: 'GET BANK 1',
-      sum: revenuesResponse.amountSum,
-      sumAll,
-      statementsDates,
-    });
-    return { todaySum, allSum: sumAll, statements: newStatements };
+    const countSum = revenuesResponse.ticketCount;
+    return { todaySum, allSum, countSum, statements: newStatements };
   }
 
   //#endregion mockData

--- a/src/bank-statements/interfaces/bank-statements-response.interface.ts
+++ b/src/bank-statements/interfaces/bank-statements-response.interface.ts
@@ -4,5 +4,6 @@ export interface IBankStatementsResponse {
   amountSum: number;
   todaySum: number;
   count: number;
+  ticketCount: number;
   data: ICoreBankStatements[];
 }

--- a/src/core-bank/data/core-bank-data.service.ts
+++ b/src/core-bank/data/core-bank-data.service.ts
@@ -132,10 +132,7 @@ export class CoreBankDataService implements OnModuleInit {
     const { paymentWeekday, nextPaymentWeekday } = this.bankStatementsArgs;
     for (const profile of this.getProfiles()) {
       let id = 1;
-      if (
-        now.getUTCDay() !== paymentWeekday &&
-        nextPaymentWeekday(now) <= lastDayOfMonth(now)
-      ) {
+      if (nextPaymentWeekday(now) <= lastDayOfMonth(now)) {
         bankStatements.push(
           this.generateBankStatement({
             id: id,

--- a/src/ticket-revenues/interfaces/ticket-revenues-grouped-response.interface.ts
+++ b/src/ticket-revenues/interfaces/ticket-revenues-grouped-response.interface.ts
@@ -4,5 +4,6 @@ export interface ITicketRevenuesGroupedResponse {
   amountSum: number;
   todaySum: number;
   count: number;
+  ticketCount: number;
   data: ITicketRevenuesGroup[];
 }

--- a/src/ticket-revenues/ticket-revenues.service.ts
+++ b/src/ticket-revenues/ticket-revenues.service.ts
@@ -126,6 +126,7 @@ export class TicketRevenuesService {
         amountSum: 0,
         todaySum: 0,
         count: 0,
+        ticketCount: 0,
         data: [],
       };
     }
@@ -168,10 +169,16 @@ export class TicketRevenuesService {
         .toFixed(2),
     );
 
+    const ticketCount = ticketRevenuesGroups.reduce(
+      (sum, i) => sum + i.count,
+      0,
+    );
+
     return {
       amountSum,
       todaySum: transactionValueLastDay,
       count: ticketRevenuesGroups.length,
+      ticketCount,
       data: ticketRevenuesGroups,
     };
   }

--- a/src/utils/payment-date-utils.ts
+++ b/src/utils/payment-date-utils.ts
@@ -138,15 +138,14 @@ export function getPaymentMonth(
       endDate: endOfMonth(fridayDate),
     };
   } else {
+    // if ticket-revenues
     // get first friday of month and friday
     let startDate = startOfMonth(new Date(fridayDate));
-    if (!isFriday(startDate)) {
-      startDate = nextFriday(startDate);
-    }
+    startDate = nextFriday(startDate);
     let endDate = new Date(fridayDate);
-    if (!isFriday(endDate) && isSameMonth(endDate, nextFriday(endDate))) {
+    if (isSameMonth(endDate, nextFriday(endDate))) {
       endDate = nextFriday(endDate);
-    } else if (!isFriday(endDate)) {
+    } else {
       endDate = previousFriday(endDate);
     }
 


### PR DESCRIPTION
## Mudanças
- 🐞 fix: A próxima sexta sempre aparece se for no mesmo mês.
- 🧪 test: Sempre mostrar a próxima sexta se for no mesmo mês
- 🧪 test: Contagem de catracadas em `bank-statements` deve ser igual em `ticket-revenues/grouped/me`