### PR TITLE
Hotfix/#142 flag mail report

### DIFF
--- a/src/settings/app.settings.ts
+++ b/src/settings/app.settings.ts
@@ -58,6 +58,14 @@ export const appSettings = {
     settingType: SettingTypeEnum.string,
   } as SettingDataInterface,
 
+  any__mail_report_enabled: {
+    name: 'mail_report_enabled',
+    value: 'false',
+    version: null,
+    editable: false,
+    settingType: SettingTypeEnum.boolean,
+  } as SettingDataInterface,
+
   // v1
 
   v1__ab_test_enabled: {


### PR DESCRIPTION
## ⚠️ Mudanças nas variáveis do banco

Para continuar enviando email diário de estatística, após finalizar o deploy em produção altere este campo no banco de dados:
```sql
UPDATE public.setting
	SET value='true'
	WHERE "name" = 'mail_report_enabled' AND "version" IS NULL
```

Resultado esperado:

id | name | value | version | editable | settingTypeId
-- | -- | -- | -- | -- | --
_n_ | mail_report_enabled | `true` | _null_ | false | `1` (boolean)