### PR TITLE
Feature: (dev) Campos adicionais no relatório diário

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-cct",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "author": "",
   "private": true,

--- a/src/config/config.type.ts
+++ b/src/config/config.type.ts
@@ -78,7 +78,6 @@ export type MailConfig = {
   secure: boolean;
   requireTLS: boolean;
   senderNotification?: string;
-  recipientStatusReport?: string;
 };
 
 export type TwitterConfig = {

--- a/src/config/mail.config.ts
+++ b/src/config/mail.config.ts
@@ -65,7 +65,6 @@ export default registerAs<MailConfig>('mail', () => {
     secure: process.env.MAIL_SECURE === 'true',
     requireTLS: process.env.MAIL_REQUIRE_TLS === 'true',
     dailyQuota: process.env.MAIL_DAILY_QUOTA,
-    recipientStatusReport: 'marcosbernardo@hotmail.com',
     senderNotification: 'notificacao.smtr@gmail.com',
   };
 });

--- a/src/cron-jobs/cron-jobs.service.ts
+++ b/src/cron-jobs/cron-jobs.service.ts
@@ -10,7 +10,7 @@ import { MailHistoryService } from 'src/mail-history/mail-history.service';
 import { MailService } from 'src/mail/mail.service';
 import { appSettings } from 'src/settings/app.settings';
 import { SettingEntity } from 'src/settings/entities/setting.entity';
-import { SettingDataInterface } from 'src/settings/interfaces/setting-data.interface';
+import { ISettingData } from 'src/settings/interfaces/setting-data.interface';
 import { SettingsService } from 'src/settings/settings.service';
 import { UsersService } from 'src/users/users.service';
 import {
@@ -36,9 +36,9 @@ interface ICronJob {
 }
 
 interface ICronJobSetting {
-  setting: SettingDataInterface;
+  setting: ISettingData;
   cronJob: CrobJobsEnum;
-  isEnabledFlag?: SettingDataInterface;
+  isEnabledFlag?: ISettingData;
 }
 
 @Injectable()
@@ -353,24 +353,27 @@ export class CronJobsService implements OnModuleInit {
       return;
     }
 
-    const recipientMail = await this.configService.get(
-      'mail.recipientStatusReport',
-    );
+    const mailRecipients =
+      await this.settingsService.findManyBySettingDataGroup(
+        appSettings.any__mail_report_recipient,
+      );
 
-    if (!recipientMail) {
+    if (!mailRecipients) {
       this.logger.error(
         formatLog(
-          `Tarefa cancelada pois a variável de ambiente 'MAIL_RECIPIENT_STATUS_REPORT'` +
-            ` não foi encontrada (retornou: ${recipientMail}).`,
+          `Tarefa cancelada pois a configuração 'mail.statusReportRecipients'` +
+            ` não foi encontrada (retornou: ${mailRecipients}).`,
           'sendStatusReport()',
         ),
       );
       return;
-    } else if (!validateEmail(recipientMail)) {
+    } else if (
+      mailRecipients.some((i) => !validateEmail(i.getValueAsString()))
+    ) {
       this.logger.error(
         formatLog(
-          `Tarefa cancelada pois a variável de ambiente 'MAIL_RECIPIENT_STATUS_REPORT'` +
-            ` não é um email válido (retornou: ${recipientMail}).`,
+          `Tarefa cancelada pois a configuração 'mail.statusReportRecipients'` +
+            ` não contém uma lista de emails válidos. Retornou: ${mailRecipients}.`,
           THIS_METHOD,
         ),
       );
@@ -378,41 +381,49 @@ export class CronJobsService implements OnModuleInit {
     }
 
     // Send mail
-    try {
-      const mailSentInfo = await this.mailService.sendStatusReport({
-        to: recipientMail,
-        data: {
-          statusCount: await this.mailHistoryService.getStatusCount(),
-        },
-      });
+    for (const mailRecipient of mailRecipients) {
+      const email = mailRecipient.getValueAsString();
+      try {
+        const mailSentInfo = await this.mailService.sendStatusReport({
+          to: email,
+          data: {
+            statusCount: await this.mailHistoryService.getStatusCount(),
+          },
+        });
 
-      // Success
-      if (mailSentInfo.success === true) {
-        this.logger.log(formatLog('Email enviado com sucesso.', THIS_METHOD));
-      }
+        // Success
+        if (mailSentInfo.success === true) {
+          this.logger.log(
+            formatLog(
+              `Relatório enviado com sucesso para o email '${email}'`,
+              THIS_METHOD,
+            ),
+          );
+        }
 
-      // SMTP error
-      else {
+        // SMTP error
+        else {
+          this.logger.error(
+            formatErrorLog(
+              `Relatório enviado para o email '${email}' retornou erro`,
+              mailSentInfo,
+              new Error(),
+              THIS_METHOD,
+            ),
+          );
+        }
+
+        // API error
+      } catch (httpException) {
         this.logger.error(
           formatErrorLog(
-            'Email enviado retornou erro.',
-            mailSentInfo,
-            new Error(),
+            `Email falhou ao enviar para '${email}'`,
+            httpException,
+            httpException as Error,
             THIS_METHOD,
           ),
         );
       }
-
-      // API error
-    } catch (httpException) {
-      this.logger.error(
-        formatErrorLog(
-          'Email falhou ao enviar.',
-          httpException,
-          httpException as Error,
-          THIS_METHOD,
-        ),
-      );
     }
     this.logger.log(formatLog('Tarefa finalizada.', THIS_METHOD));
   }

--- a/src/cron-jobs/cron-jobs.service.ts
+++ b/src/cron-jobs/cron-jobs.service.ts
@@ -381,49 +381,50 @@ export class CronJobsService implements OnModuleInit {
     }
 
     // Send mail
-    for (const mailRecipient of mailRecipients) {
-      const email = mailRecipient.getValueAsString();
-      try {
-        const mailSentInfo = await this.mailService.sendStatusReport({
-          to: email,
-          data: {
-            statusCount: await this.mailHistoryService.getStatusCount(),
-          },
-        });
+    const emails = mailRecipients.reduce(
+      (l: string[], i) => [...l, i.getValueAsString()],
+      [],
+    );
+    try {
+      const mailSentInfo = await this.mailService.sendStatusReport({
+        to: emails,
+        data: {
+          statusCount: await this.mailHistoryService.getStatusCount(),
+        },
+      } as any);
 
-        // Success
-        if (mailSentInfo.success === true) {
-          this.logger.log(
-            formatLog(
-              `Relatório enviado com sucesso para o email '${email}'`,
-              THIS_METHOD,
-            ),
-          );
-        }
-
-        // SMTP error
-        else {
-          this.logger.error(
-            formatErrorLog(
-              `Relatório enviado para o email '${email}' retornou erro`,
-              mailSentInfo,
-              new Error(),
-              THIS_METHOD,
-            ),
-          );
-        }
-
-        // API error
-      } catch (httpException) {
-        this.logger.error(
-          formatErrorLog(
-            `Email falhou ao enviar para '${email}'`,
-            httpException,
-            httpException as Error,
+      // Success
+      if (mailSentInfo.success === true) {
+        this.logger.log(
+          formatLog(
+            `Relatório enviado com sucesso para os emails ${emails}`,
             THIS_METHOD,
           ),
         );
       }
+
+      // SMTP error
+      else {
+        this.logger.error(
+          formatErrorLog(
+            `Relatório enviado para os emails ${emails} retornou erro`,
+            mailSentInfo,
+            new Error(),
+            THIS_METHOD,
+          ),
+        );
+      }
+
+      // API error
+    } catch (httpException) {
+      this.logger.error(
+        formatErrorLog(
+          `Email falhou ao enviar para ${emails}`,
+          httpException,
+          httpException as Error,
+          THIS_METHOD,
+        ),
+      );
     }
     this.logger.log(formatLog('Tarefa finalizada.', THIS_METHOD));
   }

--- a/src/database/seeds/setting/setting-seed-data.ts
+++ b/src/database/seeds/setting/setting-seed-data.ts
@@ -1,7 +1,6 @@
 import { appSettings } from 'src/settings/app.settings';
-import { SettingDataInterface } from 'src/settings/interfaces/setting-data.interface';
 import { SettingsRecordType } from 'src/settings/types/settings-record.type';
 
-export const settingSeedData: SettingDataInterface[] = [
+export const settingSeedData = [
   ...Object.values(appSettings as SettingsRecordType),
 ];

--- a/src/database/seeds/setting/setting-seed.service.ts
+++ b/src/database/seeds/setting/setting-seed.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { SettingTypeEnum } from 'src/setting-types/setting-type.enum';
+import { SettingEntity } from 'src/settings/entities/setting.entity';
+import { ISettingData } from 'src/settings/interfaces/setting-data.interface';
+import { Enum } from 'src/utils/enum';
 import { IsNull, Repository } from 'typeorm';
 import { settingSeedData } from './setting-seed-data';
-import { SettingEntity } from 'src/settings/entities/setting.entity';
-import { SettingTypeEnum } from 'src/setting-types/setting-type.enum';
-import { Enum } from 'src/utils/enum';
 
 @Injectable()
 export class SettingSeedService {
@@ -16,33 +17,36 @@ export class SettingSeedService {
   async run() {
     let id = 1;
     for (const item of settingSeedData) {
-      const count = await this.repository.count({
-        where: {
-          name: item.name,
-          version: item.version === null ? IsNull() : item.version,
-          settingType: {
-            id: item.settingType,
-            name: Enum.getKey(SettingTypeEnum, item.settingType),
-          },
-        },
-      });
-
-      if (!count) {
-        await this.repository.save(
-          this.repository.create({
-            id: id,
-            name: item.name,
-            value: item.value,
-            version: item.version,
-            editable: item.editable,
+      const settings: ISettingData[] = (item as any)?.data || [item];
+      for (const setting of settings) {
+        const itemFound = await this.repository.count({
+          where: {
+            name: setting.name,
+            version: setting.version === null ? IsNull() : setting.version,
             settingType: {
-              id: item.settingType,
-              name: Enum.getKey(SettingTypeEnum, item.settingType),
+              id: setting.settingType,
+              name: Enum.getKey(SettingTypeEnum, setting.settingType),
             },
-          }),
-        );
+          },
+        });
+
+        if (!itemFound) {
+          await this.repository.save(
+            this.repository.create({
+              id: id,
+              name: setting.name,
+              value: setting.value,
+              version: setting.version,
+              editable: setting.editable,
+              settingType: {
+                id: setting.settingType,
+                name: Enum.getKey(SettingTypeEnum, setting.settingType),
+              },
+            }),
+          );
+        }
+        id++;
       }
-      id++;
     }
   }
 }

--- a/src/mail-history-statuses/interfaces/mail-history-status-group.interface.ts
+++ b/src/mail-history-statuses/interfaces/mail-history-status-group.interface.ts
@@ -2,5 +2,7 @@ export interface IMailHistoryStatusCount {
   queued: number;
   sent: number;
   used: number;
+  usedIncomplete: number;
+  usedComplete: number;
   total: number;
 }

--- a/src/mail/interfaces/mail-data.interface.ts
+++ b/src/mail/interfaces/mail-data.interface.ts
@@ -1,4 +1,6 @@
+import { Address } from '@nestjs-modules/mailer/dist/interfaces/send-mail-options.interface';
+
 export interface MailData<T = never> {
-  to: string;
+  to: string | Address | Array<string | Address>;
   data: T;
 }

--- a/src/mail/mail-templates/report.hbs
+++ b/src/mail/mail-templates/report.hbs
@@ -55,11 +55,11 @@
                             <td>{{mailUsed}}</td>
                         </tr>
                         <tr>
-                            <td>&nbsp;&nbsp;&nbsp;&nbsp;PREENCHIDO</td>
+                            <td>&nbsp;&nbsp;&nbsp;&nbsp;CONTA CADASTADA</td>
                             <td>{{mailUsedComplete}}</td>
                         </tr>
                         <tr>
-                            <td>&nbsp;&nbsp;&nbsp;&nbsp;NÃO PREENCHIDO</td>
+                            <td>&nbsp;&nbsp;&nbsp;&nbsp;CONTA NÃO CADASTRADA</td>
                             <td>{{mailUsedIncomplete}}</td>
                         </tr>
                         <tr>

--- a/src/mail/mail-templates/report.hbs
+++ b/src/mail/mail-templates/report.hbs
@@ -55,6 +55,14 @@
                             <td>{{mailUsed}}</td>
                         </tr>
                         <tr>
+                            <td>&nbsp;&nbsp;&nbsp;&nbsp;PREENCHIDO</td>
+                            <td>{{mailUsedComplete}}</td>
+                        </tr>
+                        <tr>
+                            <td>&nbsp;&nbsp;&nbsp;&nbsp;NÃO PREENCHIDO</td>
+                            <td>{{mailUsedIncomplete}}</td>
+                        </tr>
+                        <tr>
                             <td style="font-style: italic;">Total</td>
                             <td>{{mailTotal}}</td>
                         </tr>

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -3,15 +3,15 @@ import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { I18nContext } from 'nestjs-i18n';
 import { AllConfigType } from 'src/config/config.type';
+import { IMailHistoryStatusCount } from 'src/mail-history-statuses/interfaces/mail-history-status-group.interface';
 import { SmtpStatus } from 'src/utils/enums/smtp-status.enum';
+import { formatLog } from 'src/utils/logging';
 import { MaybeType } from '../utils/types/maybe.type';
 import { EhloStatus } from './enums/ehlo-status.enum';
 import { MailData } from './interfaces/mail-data.interface';
 import { MailRegistrationInterface } from './interfaces/mail-registration.interface';
 import { MailSentInfo } from './interfaces/mail-sent-info.interface';
 import { MySentMessageInfo } from './interfaces/nodemailer/sent-message-info';
-import { formatLog } from 'src/utils/logging';
-import { IMailHistoryStatusCount } from 'src/mail-history-statuses/interfaces/mail-history-status-group.interface';
 
 @Injectable()
 export class MailService {
@@ -201,6 +201,8 @@ export class MailService {
           mailQueued: mailData.data.statusCount.queued,
           mailSent: mailData.data.statusCount.sent,
           mailUsed: mailData.data.statusCount.used,
+          mailUsedIncomplete: mailData.data.statusCount.usedIncomplete,
+          mailUsedComplete: mailData.data.statusCount.usedComplete,
           mailTotal: mailData.data.statusCount.total,
         },
       });

--- a/src/settings/app.settings.ts
+++ b/src/settings/app.settings.ts
@@ -1,6 +1,7 @@
-import { SettingTypeEnum } from 'src/setting-types/setting-type.enum';
-import { SettingDataInterface } from './interfaces/setting-data.interface';
 import { CronExpression } from '@nestjs/schedule';
+import { SettingTypeEnum } from 'src/setting-types/setting-type.enum';
+import { ISettingDataGroup } from './interfaces/setting-data-group.interface';
+import { ISettingData } from './interfaces/setting-data.interface';
 
 /**
  * Helper for default settings
@@ -15,7 +16,7 @@ export const appSettings = {
     version: null,
     editable: true,
     settingType: SettingTypeEnum.boolean,
-  } as SettingDataInterface,
+  } as ISettingData,
 
   /** Hours in UTC */
   any__auto_send_invite_schedule_hours: {
@@ -24,7 +25,7 @@ export const appSettings = {
     version: null,
     editable: false,
     settingType: SettingTypeEnum.number,
-  } as SettingDataInterface,
+  } as ISettingData,
 
   any__poll_db_enabled: {
     name: 'poll_db_enabled',
@@ -32,7 +33,7 @@ export const appSettings = {
     version: null,
     editable: false,
     settingType: SettingTypeEnum.boolean,
-  } as SettingDataInterface,
+  } as ISettingData,
 
   any__poll_db_cronjob: {
     name: 'poll_db_cronjob',
@@ -40,7 +41,7 @@ export const appSettings = {
     version: null,
     editable: false,
     settingType: SettingTypeEnum.string,
-  } as SettingDataInterface,
+  } as ISettingData,
 
   any__mail_invite_cronjob: {
     name: 'mail_invite_cronjob',
@@ -48,7 +49,7 @@ export const appSettings = {
     version: null,
     editable: false,
     settingType: SettingTypeEnum.string,
-  } as SettingDataInterface,
+  } as ISettingData,
 
   any__mail_report_cronjob: {
     name: 'mail_report_cronjob',
@@ -56,7 +57,7 @@ export const appSettings = {
     version: null,
     editable: false,
     settingType: SettingTypeEnum.string,
-  } as SettingDataInterface,
+  } as ISettingData,
 
   any__mail_report_enabled: {
     name: 'mail_report_enabled',
@@ -64,7 +65,28 @@ export const appSettings = {
     version: null,
     editable: false,
     settingType: SettingTypeEnum.boolean,
-  } as SettingDataInterface,
+  } as ISettingData,
+
+  any__mail_report_recipient: {
+    baseName: 'mail_report_recipient',
+    baseVersion: null,
+    data: [
+      {
+        name: 'mail_report_recipient_1',
+        value: 'marcosbernardo@hotmail.com',
+        version: null,
+        editable: false,
+        settingType: SettingTypeEnum.string,
+      } as ISettingData,
+      {
+        name: 'mail_report_recipient_2',
+        value: 'laurosilvestre.smtr@gmail.com',
+        version: null,
+        editable: false,
+        settingType: SettingTypeEnum.string,
+      } as ISettingData,
+    ],
+  } as ISettingDataGroup,
 
   // v1
 
@@ -74,12 +96,12 @@ export const appSettings = {
     version: '1',
     editable: false,
     settingType: SettingTypeEnum.boolean,
-  } as SettingDataInterface,
+  } as ISettingData,
   v1__user_file_max_upload_size: {
     name: 'user_file_max_upload_size',
     value: '10MB',
     version: '1',
     editable: false,
     settingType: SettingTypeEnum.string,
-  } as SettingDataInterface,
+  } as ISettingData,
 };

--- a/src/settings/interfaces/setting-data-group.interface.ts
+++ b/src/settings/interfaces/setting-data-group.interface.ts
@@ -1,0 +1,7 @@
+import { ISettingData } from './setting-data.interface';
+
+export interface ISettingDataGroup {
+  baseName: string;
+  baseVersion: string | null;
+  data: ISettingData[];
+}

--- a/src/settings/interfaces/setting-data.interface.ts
+++ b/src/settings/interfaces/setting-data.interface.ts
@@ -1,6 +1,6 @@
 import { SettingTypeEnum } from '../../setting-types/setting-type.enum';
 
-export interface SettingDataInterface {
+export interface ISettingData {
   name: string;
   value: string;
   version: string | null;

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -1,12 +1,13 @@
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { formatLog } from 'src/utils/logging';
 import { EntityCondition } from 'src/utils/types/entity-condition.type';
 import { NullableType } from 'src/utils/types/nullable.type';
-import { IsNull, Repository } from 'typeorm';
+import { IsNull, Like, Repository } from 'typeorm';
 import { UpdateSettingsDto } from './dto/update-settings.dto';
 import { SettingEntity } from './entities/setting.entity';
-import { SettingDataInterface } from './interfaces/setting-data.interface';
-import { formatLog } from 'src/utils/logging';
+import { ISettingDataGroup } from './interfaces/setting-data-group.interface';
+import { ISettingData } from './interfaces/setting-data.interface';
 
 @Injectable()
 export class SettingsService {
@@ -58,7 +59,7 @@ export class SettingsService {
   }
 
   async getOneBySettingData(
-    setting: SettingDataInterface,
+    setting: ISettingData,
     defaultValueIfNotFound?: boolean,
     logContext?: string,
   ): Promise<SettingEntity> {
@@ -78,7 +79,7 @@ export class SettingsService {
   }
 
   async findOneBySettingData(
-    setting: SettingDataInterface,
+    setting: ISettingData,
   ): Promise<SettingEntity | null> {
     const settings = await this.settingsRepository.find({
       where: {
@@ -91,6 +92,17 @@ export class SettingsService {
     } else {
       return settings[0];
     }
+  }
+
+  async findManyBySettingDataGroup(
+    setting: ISettingDataGroup,
+  ): Promise<SettingEntity[]> {
+    return await this.settingsRepository.find({
+      where: {
+        name: Like(`%${setting.baseName}%`),
+        version: setting.baseVersion === null ? IsNull() : setting.baseVersion,
+      },
+    });
   }
 
   async findByVersion(version: string): Promise<SettingEntity[]> {

--- a/src/settings/types/settings-record.type.ts
+++ b/src/settings/types/settings-record.type.ts
@@ -1,3 +1,7 @@
-import { SettingDataInterface } from '../interfaces/setting-data.interface';
+import { ISettingDataGroup } from '../interfaces/setting-data-group.interface';
+import { ISettingData } from '../interfaces/setting-data.interface';
 
-export type SettingsRecordType = Record<string, SettingDataInterface>;
+export type SettingsRecordType = Record<
+  string,
+  ISettingData | ISettingDataGroup
+>;


### PR DESCRIPTION
## ⚠️ Mudança no setting

Novos campos:

id | name | value | version | editable | settingTypeId
-- | -- | -- | -- | -- | --
10 | mail_report_recipient_1 | `marcosbernardo@hotmail.com` | _null_  | false | `2` (string)
11 | mail_report_recipient_2 | `laurosilvestre.smtr@gmail.com` | _null_  | false | `2` (string)

Esses campos são adicionados no seed.
Se precisar adicionar mais destinatários basta criar no banco um novo campo `mail_report_recipient_3` e afins. O sistema automaticamente busca por campos com o prefixo `mail_report_recipient`

## Mudanças

- chore: v0.0.9
- feat: enviar relatório para 2 ou mais destinatários (setting)
