### PR TITLE
Hotfix: (dev) Remover validação de campos desnecessários 

### DIFF
--- a/src/mail-history/mail-history.service.ts
+++ b/src/mail-history/mail-history.service.ts
@@ -207,8 +207,6 @@ export class MailHistoryService {
           `"user"."cpfCnpj" IS NOT NULL AND "user"."cpfCnpj" != '' AND ` +
           `"user"."permitCode" IS NOT NULL AND "user"."permitCode" != '' AND ` +
           `"user"."email" IS NOT NULL AND "user"."email" != '' AND ` +
-          `"user"."passValidatorId" IS NOT NULL AND "user"."passValidatorId" != '' AND ` +
-          `"user"."isSgtuBlocked" = TRUE AND ` +
           `"user"."phone" IS NOT NULL AND "user"."phone" != '' AND ` +
           `"user"."bankCode" IS NOT NULL AND ` +
           `"user"."bankAgency" IS NOT NULL AND "user"."bankAgency" != '' AND ` +

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -156,8 +156,6 @@ export class User extends EntityHelper {
       Boolean(this.cpfCnpj) &&
       Boolean(this.permitCode) &&
       Boolean(this.email) &&
-      Boolean(this.passValidatorId) &&
-      this.isSgtuBlocked !== undefined &&
       // editable
       Boolean(this.phone) &&
       Boolean(this.bankCode) &&


### PR DESCRIPTION
Ref #155 

Para validar se o usuário preencheu todos os campos irá verificar se os campos abaixo foram preenchidos no banco:
- Código de permissão
- Nome
- E-mail
- Celular
- Banco
- Agência
- Conta
- Dígito

Nesta correção foi removida a validação dos campos extras abaixo:
- Código de validador
- Usuário está bloqueado no SGTU