### PR TITLE
Feat/298 financeiro columns

### DIFF
--- a/src/bank-statements/bank-statements-repository.service.ts
+++ b/src/bank-statements/bank-statements-repository.service.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  endOfDay,
-  nextFriday,
-  startOfDay,
-  subDays
-} from 'date-fns';
+import { endOfDay, nextFriday, startOfDay, subDays } from 'date-fns';
 import { DetalheAService } from 'src/cnab/service/pagamento/detalhe-a.service';
 import { TicketRevenuesService } from 'src/ticket-revenues/ticket-revenues.service';
 import { User } from 'src/users/entities/user.entity';
@@ -14,7 +9,7 @@ import { getPagination } from 'src/utils/get-pagination';
 import { PaginationOptions } from 'src/utils/types/pagination-options';
 import { Pagination } from 'src/utils/types/pagination.type';
 import { In } from 'typeorm';
-import { IBankStatement } from './interfaces/bank-statement.interface';
+import { BankStatementDTO } from './dtos/bank-statement.dto';
 import { IBSCounts } from './interfaces/bs-counts.interface';
 import { IBSGetMePreviousDaysValidArgs } from './interfaces/bs-get-me-previous-days-args.interface';
 import { IBSGetMePreviousDaysResponse } from './interfaces/bs-get-me-previous-days-response.interface';
@@ -84,7 +79,7 @@ export class BankStatementsRepositoryService {
     endDate: string;
     timeInterval?: TimeIntervalEnum;
     paginationArgs?: PaginationOptions;
-  }): Promise<Pagination<{ data: IBankStatement[] }>> {
+  }): Promise<Pagination<{ data: BankStatementDTO[] }>> {
     const pagination = validArgs.paginationArgs
       ? validArgs.paginationArgs
       : { limit: 9999, page: 1 };
@@ -163,9 +158,9 @@ export class BankStatementsRepositoryService {
         paidAmount: paidAmount,
         status: amount ? (isPago ? 'Pago' : 'A pagar') : null,
         errors,
-      } as IBankStatement;
+      } as BankStatementDTO;
     });
-    return getPagination<{ data: IBankStatement[] }>(
+    return getPagination<{ data: BankStatementDTO[] }>(
       {
         data: statements,
       },
@@ -178,7 +173,7 @@ export class BankStatementsRepositoryService {
   }
 
   private generateStatusCounts(
-    data: IBankStatement[],
+    data: BankStatementDTO[],
   ): Record<string, IBSCounts> {
     const statusCounts: Record<string, IBSCounts> = {};
     for (const item of data) {

--- a/src/bank-statements/bank-statements.service.spec.ts
+++ b/src/bank-statements/bank-statements.service.spec.ts
@@ -10,7 +10,7 @@ import { getDateYMDString } from 'src/utils/date-utils';
 import { TimeIntervalEnum } from 'src/utils/enums/time-interval.enum';
 import { BankStatementsRepositoryService } from './bank-statements-repository.service';
 import { BankStatementsService } from './bank-statements.service';
-import { IBankStatement } from './interfaces/bank-statement.interface';
+import { BankStatementDTO } from './dtos/bank-statement.dto';
 import { SettingsService } from 'src/settings/settings.service';
 
 const allBankStatements = [
@@ -22,7 +22,7 @@ const allBankStatements = [
   ...i,
   cpfCnpj: 'cc_1',
   permitCode: 'pc_1',
-})) as Partial<IBankStatement>[] as IBankStatement[];
+})) as Partial<BankStatementDTO>[] as BankStatementDTO[];
 
 xdescribe('BankStatementsService', () => {
   // const endpoint = 'bank-statements';

--- a/src/bank-statements/dtos/bank-statement.dto.ts
+++ b/src/bank-statements/dtos/bank-statement.dto.ts
@@ -1,4 +1,12 @@
-export interface IBankStatement {
+import { SetValueIf } from 'src/utils/decorators/set-value-if.decorator';
+
+export class BankStatementDTO {
+  constructor(dto?: BankStatementDTO) {
+    if (dto) {
+      Object.assign(this, dto);
+    }
+  }
+
   id: number;
   /**
    * feiday date.
@@ -18,9 +26,11 @@ export interface IBankStatement {
   permitCode: string;
   cpfCnpj: string;
   amount: number;
+
+  @SetValueIf((o) => o.status === 'Pago', 0)
   paidAmount: number;
 
-  /** Business status message */
+  /** Payment status */
   status: string | null;
 
   /** Bank error message */

--- a/src/bank-statements/dtos/bank-statement.dto.ts
+++ b/src/bank-statements/dtos/bank-statement.dto.ts
@@ -27,7 +27,7 @@ export class BankStatementDTO {
   cpfCnpj: string;
   amount: number;
 
-  @SetValueIf((o) => o.status === 'Pago', 0)
+  @SetValueIf((o) => o.status !== 'Pago', 0)
   paidAmount: number;
 
   /** Payment status */

--- a/src/bank-statements/interfaces/bs-get-me-previous-days-response.interface.ts
+++ b/src/bank-statements/interfaces/bs-get-me-previous-days-response.interface.ts
@@ -1,7 +1,7 @@
-import { IBankStatement } from './bank-statement.interface';
+import { BankStatementDTO } from '../dtos/bank-statement.dto';
 import { IBSCounts } from './bs-counts.interface';
 
 export class IBSGetMePreviousDaysResponse {
   statusCounts: Record<string, IBSCounts>;
-  data: IBankStatement[];
+  data: BankStatementDTO[];
 }

--- a/src/bank-statements/interfaces/bs-get-me-response.interface.ts
+++ b/src/bank-statements/interfaces/bs-get-me-response.interface.ts
@@ -1,4 +1,4 @@
-import { IBankStatement } from './bank-statement.interface';
+import { BankStatementDTO } from "../dtos/bank-statement.dto";
 
 export interface IBSGetMeResponse {
   amountSum: number;
@@ -6,5 +6,5 @@ export interface IBSGetMeResponse {
   paidSum: number;
   count: number;
   ticketCount: number;
-  data: IBankStatement[];
+  data: BankStatementDTO[];
 }

--- a/src/bank-statements/interfaces/get-bs-response.interface.ts
+++ b/src/bank-statements/interfaces/get-bs-response.interface.ts
@@ -1,8 +1,8 @@
-import { IBankStatement } from './bank-statement.interface';
+import { BankStatementDTO } from '../dtos/bank-statement.dto';
 
 export interface IGetBSResponse {
   todaySum: number;
   allSum: number;
   countSum: number;
-  statements: IBankStatement[];
+  statements: BankStatementDTO[];
 }

--- a/src/bigquery/entities/transacao.bigquery-entity.ts
+++ b/src/bigquery/entities/transacao.bigquery-entity.ts
@@ -30,5 +30,6 @@ export class BigqueryTransacao {
   stop_lat: number | null;
   stop_lon: number | null;
   valor_transacao: number;
+  valor_pagamento: number;
   versao: string | null;
 }

--- a/src/bigquery/interfaces/bq-find-transacao-by.interface.ts
+++ b/src/bigquery/interfaces/bq-find-transacao-by.interface.ts
@@ -1,5 +1,6 @@
 export interface IBqFindTransacao {
   cpfCnpj?: string;
+  manyCpfCnpj?: string[];
   startDate?: Date;
   endDate?: Date;
   limit?: number;

--- a/src/bigquery/repositories/bigquery-ordem-pagamento.repository.spec.ts
+++ b/src/bigquery/repositories/bigquery-ordem-pagamento.repository.spec.ts
@@ -5,7 +5,7 @@ import { BigqueryService } from 'src/bigquery/bigquery.service';
 import { SettingEntity } from 'src/settings/entities/setting.entity';
 import { BigqueryEnvironment } from 'src/settings/enums/bigquery-env.enum';
 import { SettingsService } from 'src/settings/settings.service';
-import { testLoadEnv, testGetBigqueryCredentials } from 'src/test/test-utils';
+import { testGetBigqueryCredentials, testLoadEnv } from 'src/test/test-utils';
 import { BigqueryOrdemPagamentoRepository } from './bigquery-ordem-pagamento.repository';
 
 describe('BigqueryOrdemPagamentoRepository', () => {
@@ -80,14 +80,28 @@ describe('BigqueryOrdemPagamentoRepository', () => {
       } as SettingEntity);
 
       // Act
-      const transacao = await bqOrdemPagamentoRepository.query(`
-        SELECT *
-        FROM \`rj-smtr-dev.br_rj_riodejaneiro_bilhetagem.transacao\`
-        LIMIT 10
-      `);
+//       const operadora = await bqOrdemPagamentoRepository.query(
+//         `
+// SELECT t.modo, o.operadora, c.consorcio, c.cnpj, o.documento, t.id_consorcio, t.id_operadora
+// FROM \`rj-smtr.br_rj_riodejaneiro_bilhetagem.transacao\` t
+// LEFT JOIN \`rj-smtr.cadastro.consorcios\` c ON c.id_consorcio = t.id_consorcio
+// LEFT JOIN \`rj-smtr.cadastro.operadoras\` o ON o.id_operadora = t.id_operadora
+// WHERE o.documento IN ('03818429405', '10204153719')
+//         `,
+//       );
+      const consorcio = await bqOrdemPagamentoRepository.query(
+        `
+SELECT t.modo, c.consorcio, o.operadora, c.cnpj, o.documento, t.id_consorcio, t.id_operadora
+FROM \`rj-smtr.br_rj_riodejaneiro_bilhetagem.transacao\` t
+LEFT JOIN \`rj-smtr.cadastro.consorcios\` c ON c.id_consorcio = t.id_consorcio
+LEFT JOIN \`rj-smtr.cadastro.operadoras\` o ON o.id_operadora = t.id_operadora
+LIMIT 10
+        `,
+      );
+      const len = consorcio[0].length;
 
       // Assert
-      expect(transacao).toBeDefined();
+      expect(len).toBeDefined();
     });
   });
 });

--- a/src/bigquery/services/bigquery-ordem-pagamento.service.ts
+++ b/src/bigquery/services/bigquery-ordem-pagamento.service.ts
@@ -21,10 +21,12 @@ export class BigqueryOrdemPagamentoService {
     const today = new Date();
     const friday = isFriday(today) ? today : nextFriday(today);
 
+    const sex = subDays(friday, 7 + daysBefore);
+    const qui = subDays(friday, 1 + daysBefore);
     const ordemPgto = (
       await this.bigqueryOrdemPagamentoRepository.findMany({
-        startDate: subDays(friday, 7 + daysBefore), // sex
-        endDate: subDays(friday, 1 + daysBefore), // qui
+        startDate: sex,
+        endDate: qui,
       })
     ).map((i) => ({ ...i } as BigqueryOrdemPagamentoDTO));
     return ordemPgto;

--- a/src/cnab/cnab.service.spec.ts
+++ b/src/cnab/cnab.service.spec.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CronJobsService } from './cron-jobs.service';
+import { ConfigService } from '@nestjs/config';
+import { Provider } from '@nestjs/common';
+import { MailHistoryService } from 'src/mail-history/mail-history.service';
+import { UsersService } from 'src/users/users.service';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { MailService } from 'src/mail/mail.service';
+import { SettingsService } from 'src/settings/settings.service';
+import { SettingEntity } from 'src/settings/entities/setting.entity';
+import { MailHistory } from 'src/mail-history/entities/mail-history.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Role } from 'src/roles/entities/role.entity';
+import { InviteStatus } from 'src/mail-history-statuses/entities/mail-history-status.entity';
+import { InviteStatusEnum } from 'src/mail-history-statuses/mail-history-status.enum';
+import { RoleEnum } from 'src/roles/roles.enum';
+import { MailRegistrationInterface } from 'src/mail/interfaces/mail-registration.interface';
+import { DeepPartial } from 'typeorm';
+
+xdescribe('CnabService', () => {
+  let cronJobsService: CronJobsService;
+  let settingsService: SettingsService;
+  let mailHistoryService: MailHistoryService;
+  let mailService: MailService;
+  let usersService: UsersService;
+
+  beforeEach(async () => {
+    const configServiceMock = {
+      provide: ConfigService,
+      useValue: {
+        getOrThrow: jest.fn(),
+      },
+    } as Provider;
+    const settingsServiceMock = {
+      provide: SettingsService,
+      useValue: {
+        getOneBySettingData: jest.fn(),
+        findOneBySettingData: jest.fn(),
+      },
+    } as Provider;
+    const mailHistoryServiceMock = {
+      provide: MailHistoryService,
+      useValue: {
+        findSentToday: jest.fn(),
+        findUnsent: jest.fn(),
+        getRemainingQuota: jest.fn(),
+        update: jest.fn(),
+      },
+    } as Provider;
+    const mailServiceMock = {
+      provide: MailService,
+      useValue: {
+        sendConcludeRegistration: jest.fn(),
+      },
+    } as Provider;
+    const usersServiceMock = {
+      provide: UsersService,
+      useValue: {
+        findOne: jest.fn(),
+      },
+    } as Provider;
+    const schedulerRegistryMock = {
+      provide: SchedulerRegistry,
+      useValue: {
+        addCronJob: jest.fn(),
+      },
+    } as Provider;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CronJobsService,
+        configServiceMock,
+        settingsServiceMock,
+        mailHistoryServiceMock,
+        mailServiceMock,
+        usersServiceMock,
+        schedulerRegistryMock,
+      ],
+    }).compile();
+
+    cronJobsService = module.get<CronJobsService>(CronJobsService);
+    settingsService = module.get<SettingsService>(SettingsService);
+    mailHistoryService = module.get<MailHistoryService>(MailHistoryService);
+    mailService = module.get<MailService>(MailService);
+    usersService = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(cronJobsService).toBeDefined();
+  });
+
+  describe('bulkSendInvites', () => {
+    xit('[FIXME] should abort if no mail quota available', /**
+     * Requirement: 2023/11/16 {@link https://github.com/RJ-SMTR/api-cct/issues/94#issuecomment-1815016208 #94, item 11 - GitHub}
+     */ async () => {
+      // Arrange
+      jest
+        .spyOn(settingsService, 'findOneBySettingData')
+        .mockResolvedValue({ value: 'true' } as SettingEntity);
+      jest.spyOn(mailHistoryService, 'findSentToday').mockResolvedValue([]);
+      jest
+        .spyOn(mailHistoryService, 'findUnsent')
+        .mockResolvedValue([{ id: 1 }, { id: 2 }] as MailHistory[]);
+      jest.spyOn(mailHistoryService, 'getRemainingQuota').mockResolvedValue(0);
+      jest
+        .spyOn(global.Date, 'now')
+        .mockImplementation(() => new Date('2023-01-01').valueOf());
+
+      // Act
+      await cronJobsService.bulkSendInvites();
+
+      // Assert
+      expect(usersService.findOne).toBeCalledTimes(0);
+      expect(mailService.sendConcludeRegistration).toBeCalledTimes(0);
+    });
+
+    xit('[FIXME] should set mail status to SENT when succeeded', /**
+     * Requirement: 2023/11/16 {@link https://github.com/RJ-SMTR/api-cct/issues/94#issuecomment-1815016208 #94, item 12 - GitHub}
+     */ async () => {
+      // Arrange
+      const dateNow = new Date('2023-01-01T10:00:00');
+      const user = new User({
+        id: 1,
+        email: 'user1@example.com',
+        hash: 'hash_1',
+        permitCode: 'permitCode1',
+        role: new Role(RoleEnum.user),
+      });
+      const mailHistory = {
+        id: 1,
+        user: user,
+        hash: 'hash_1',
+        inviteStatus: new InviteStatus(InviteStatusEnum.sent),
+        sentAt: dateNow,
+      } as MailHistory;
+      const updatedMailHistory = {
+        failedAt: null,
+        sentAt: dateNow,
+        httpErrorCode: null,
+        smtpErrorCode: null,
+        inviteStatus: new InviteStatus(InviteStatusEnum.sent),
+      } as DeepPartial<MailHistory>;
+      const mailResponse = {
+        mailConfirmationLink: 'link',
+        mailSentInfo: {
+          success: true,
+        },
+      } as MailRegistrationInterface;
+
+      jest
+        .spyOn(settingsService, 'findOneBySettingData')
+        .mockResolvedValue({ value: 'true' } as SettingEntity);
+      jest.spyOn(mailHistoryService, 'findSentToday').mockResolvedValue([]);
+      jest
+        .spyOn(mailHistoryService, 'findUnsent')
+        .mockResolvedValue([mailHistory] as MailHistory[]);
+      jest.spyOn(mailHistoryService, 'getRemainingQuota').mockResolvedValue(1);
+      jest.spyOn(usersService, 'findOne').mockResolvedValue(user);
+      jest
+        .spyOn(mailService, 'sendConcludeRegistration')
+        .mockResolvedValue(mailResponse);
+      jest
+        .spyOn(global.Date, 'now')
+        .mockImplementation(() => dateNow.valueOf());
+
+      // Act
+      await cronJobsService.bulkSendInvites();
+
+      // Assert
+      expect(usersService.findOne).toBeCalled();
+      expect(mailService.sendConcludeRegistration).toBeCalled();
+      expect(mailHistoryService.update).toBeCalledWith(
+        1,
+        updatedMailHistory,
+        expect.any(String),
+      );
+    });
+  });
+});

--- a/src/cnab/cnab.service.ts
+++ b/src/cnab/cnab.service.ts
@@ -19,6 +19,7 @@ import { SftpService } from 'src/sftp/sftp.service';
 import { TransacaoView } from 'src/transacao-bq/transacao-view.entity';
 import { TransacaoViewService } from 'src/transacao-bq/transacao-view.service';
 import { UsersService } from 'src/users/users.service';
+import { forChunk } from 'src/utils/array-utils';
 import { CustomLogger } from 'src/utils/custom-logger';
 import { yearMonthDayToDate } from 'src/utils/date-utils';
 import { asNumber } from 'src/utils/pipe-utils';
@@ -98,14 +99,14 @@ export class CnabService {
     // 1. Update cliente favorecido
     await this.updateAllFavorecidosFromUsers();
 
-    // 2. Update TransacaoBigquery
-    await this.updateTransacaoBigquery();
+    // 2. Update TransacaoView
+    await this.updateTransacaoViewBigquery();
 
     // 3. Update ordens
-    const ordens = await this.bigqueryOrdemPagamentoService.getFromWeek(7);
+    const ordens = await this.bigqueryOrdemPagamentoService.getFromWeek();
     await this.saveOrdens(ordens);
 
-    await this.compareTransacaoViewPublicacao(21);
+    await this.compareTransacaoViewPublicacao();
 
     // Log
     const msg = `Há ${ordens.length} ordens consideradas novas.`;
@@ -117,22 +118,57 @@ export class CnabService {
     }
   }
 
-  async updateTransacaoBigquery() {
-    const transacoesBq = await this.bigqueryTransacaoService.getFromWeek();
-    const transacoesView = transacoesBq.map((i) =>
-      TransacaoView.newFromBigquery(i),
+  /**
+   * Atualiza a tabela TransacaoView
+   */
+  async updateTransacaoViewBigquery(daysBack = 0) {
+    const transacoesBq = await this.bigqueryTransacaoService.getFromWeek(daysBack);
+    let chunkSize = 0;
+    forChunk(transacoesBq, 1000, async (chunk) => {
+      chunkSize += 1000;
+      this.logger.log(
+        `Inserindo ${chunkSize}/${chunk.length} itens em TransacaoView...`,
+      );
+      const transacoes = chunk.map((i) => TransacaoView.newFromBigquery(i));
+      await this.transacaoViewService.findExisting(
+        transacoes,
+        async (existing) => {
+          await this.transacaoViewService.saveMany(existing, transacoes);
+        },
+      );
+    });
+
+    // const transacoesView = transacoesBq.map((i) =>
+    //   TransacaoView.newFromBigquery(i),
+    // );
+  }
+
+  async debugUpdateAllTransacaoView() {
+    await this.bigqueryTransacaoService.getAllPaginated(
+      (transacoesBq) => {
+        let chunkSize = 0;
+        forChunk(transacoesBq, 1000, async (chunk) => {
+          chunkSize += 1000;
+          this.logger.log(
+            `Inserindo ${chunkSize}/${chunk.length} itens em TransacaoView...`,
+          );
+          const transacoes = chunk.map((i) => TransacaoView.newFromBigquery(i));
+          await this.transacaoViewService.findExisting(
+            transacoes,
+            async (existing) => {
+              await this.transacaoViewService.saveMany(existing, transacoes);
+            },
+          );
+        });
+      },
+      ['03818429405', '10204153719'],
     );
-    this.logger.log(
-      `Inserindo ${transacoesView.length} itens em TransacaoView...`,
-    );
-    await this.transacaoViewService.insertMany(transacoesView);
   }
 
   /**
-   * Salvar transacoes e agrupados
+   * Salvar Transacao / ItemTransacao e agrupados
    */
   async saveOrdens(ordens: BigqueryOrdemPagamentoDTO[]) {
-    // 3. Save Transacao / ItemTransacao
     const pagador = (await this.pagadorService.getAllPagador()).contaBilhetagem;
     for (const ordem of ordens) {
       const cpfCnpj = ordem.consorcioCnpj || ordem.operadoraCpfCnpj;
@@ -151,7 +187,7 @@ export class CnabService {
     }
   }
 
-  async compareTransacaoViewPublicacao(daysBefore=0) {
+  async compareTransacaoViewPublicacao(daysBefore = 0) {
     const transacoesView = await this.getTransacoesViewWeek(daysBefore);
     const publicacoes = await this.getPublicacoesWeek(daysBefore);
     for (const publicacao of publicacoes) {
@@ -178,7 +214,7 @@ export class CnabService {
       friday = nextFriday(friday);
     }
     const sex = startOfDay(subDays(friday, 7 + daysBefore));
-    const qui = endOfDay(subDays(friday, 1 + daysBefore));
+    const qui = endOfDay(subDays(friday, 1));
     const result = await this.arqPublicacaoService.findMany({
       where: {
         itemTransacao: {
@@ -188,8 +224,8 @@ export class CnabService {
       order: {
         itemTransacao: {
           dataOrdem: 'ASC',
-        }
-      }
+        },
+      },
     });
     return result;
   }
@@ -199,29 +235,41 @@ export class CnabService {
     pagador: Pagador,
     favorecido: ClienteFavorecido,
   ) {
-    // 1. Verificar se as colunas de agrupamento existem nas tabelas agrupadas
+    /** TransaçãoAg por pagador(cpfCnpj), dataOrdem (sexta) e status = criado
+     * Status criado
+     */
     const dataOrdem = yearMonthDayToDate(ordem.dataOrdem);
     const fridayOrdem = nextFriday(startOfDay(dataOrdem));
-
-    /** Requisito: 1 transação por pagador, status e dataOrdem (sexta) */
+    /**
+     * Um TransacaoAgrupado representa um pagador.
+     * Pois cada CNAB representa 1 conta bancária de origem
+     */
     let transacaoAg = await this.transacaoAgService.findOne({
       dataOrdem: fridayOrdem,
       pagador: { id: pagador.id },
       status: { id: TransacaoStatusEnum.created },
     });
 
+    /** ItemTransacaoAg representa o destinatário (operador ou consórcio) */
     let itemAg: ItemTransacaoAgrupado | null = null;
 
-    // Se existir TransacaoAgrupado
     if (transacaoAg) {
-      // Cria ou atualiza item
+      // Cria ou atualiza itemTransacao (somar o valor a ser pago na sexta de pagamento)
       itemAg = await this.itemTransacaoAgService.findOne({
         where: {
           transacaoAgrupado: {
             id: transacaoAg.id,
             status: { id: TransacaoStatusEnum.created },
           },
-          idConsorcio: ordem.idConsorcio, // business rule
+          /**
+           * Agrupar por destinatário (idOperadora).
+           *
+           * Se consorcio for STPC, agrupa pela operadora
+           * Senão, agrupa pelo consórico
+           */
+          ...(ordem.consorcio === 'STPC'
+            ? { idOperadora: ordem.idOperadora }
+            : { idConsorcio: ordem.idConsorcio }),
         },
       });
       if (itemAg) {
@@ -342,7 +390,7 @@ export class CnabService {
       friday = nextFriday(friday);
     }
     const qui = startOfDay(subDays(friday, 8 + daysBefore));
-    const qua = endOfDay(subDays(friday, 2 + daysBefore));
+    const qua = endOfDay(subDays(friday, 2));
     const transacoesView = await this.transacaoViewService.find(
       {
         datetimeProcessamento: Between(qui, qua),

--- a/src/cnab/entity/pagamento/item-transacao-agrupado.entity.ts
+++ b/src/cnab/entity/pagamento/item-transacao-agrupado.entity.ts
@@ -23,6 +23,8 @@ export class ItemTransacaoAgrupado extends EntityHelper {
     }
   }
 
+  private readonly FKs = ['transacaoAgrupado', 'clienteFavorecido'];
+
   @PrimaryGeneratedColumn({
     primaryKeyConstraintName: 'PK_ItemTransacaoAgrupado_id',
   })

--- a/src/cnab/repository/pagamento/item-transacao-agrupado.repository.ts
+++ b/src/cnab/repository/pagamento/item-transacao-agrupado.repository.ts
@@ -26,6 +26,31 @@ export class ItemTransacaoAgrupadoRepository {
     private itemTransacaoAgRepository: Repository<ItemTransacaoAgrupado>,
   ) {}
 
+  public async insertAsNew(
+    dto: DeepPartial<ItemTransacaoAgrupado>,
+  ): Promise<ItemTransacaoAgrupado> {
+    const _dto = structuredClone(dto);
+    if (!_dto.id) {
+      _dto.id = (await this.getMaxId()) + 1;
+    }
+    await this.itemTransacaoAgRepository
+      .createQueryBuilder()
+      .insert()
+      .into(ItemTransacaoAgrupado)
+      .values([_dto])
+      .orIgnore()
+      .execute();
+    return new ItemTransacaoAgrupado(_dto);
+  }
+
+  async getMaxId(): Promise<number> {
+    const maxId = await this.itemTransacaoAgRepository
+      .createQueryBuilder('t')
+      .select('MAX(t.id)', 'max')
+      .getRawOne();
+    return maxId.max;
+  }
+
   /**
    * Bulk update
    */

--- a/src/cnab/service/pagamento/item-transacao-agrupado.service.ts
+++ b/src/cnab/service/pagamento/item-transacao-agrupado.service.ts
@@ -2,7 +2,14 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ItemTransacaoAgrupado } from 'src/cnab/entity/pagamento/item-transacao-agrupado.entity';
 import { ItemTransacaoAgrupadoRepository } from 'src/cnab/repository/pagamento/item-transacao-agrupado.repository';
 import { CustomLogger } from 'src/utils/custom-logger';
-import { DeepPartial, FindManyOptions, FindOneOptions, FindOptionsWhere, In, UpdateResult } from 'typeorm';
+import {
+  DeepPartial,
+  FindManyOptions,
+  FindOneOptions,
+  FindOptionsWhere,
+  In,
+  UpdateResult,
+} from 'typeorm';
 
 @Injectable()
 export class ItemTransacaoAgrupadoService {
@@ -13,6 +20,10 @@ export class ItemTransacaoAgrupadoService {
   constructor(
     private itemTransacaoAgRepository: ItemTransacaoAgrupadoRepository,
   ) {}
+
+  async getMaxId(): Promise<number> {
+    return await this.itemTransacaoAgRepository.getMaxId();
+  }
 
   async findOne(options: FindOneOptions<ItemTransacaoAgrupado>) {
     return await this.itemTransacaoAgRepository.findOne(options);
@@ -63,6 +74,15 @@ export class ItemTransacaoAgrupadoService {
 
   public async findMany(options: FindManyOptions<ItemTransacaoAgrupado>) {
     return await this.itemTransacaoAgRepository.findMany(options);
+  }
+
+  /**
+   * Insert with a new generated id
+   */
+  public async insert(
+    dto: DeepPartial<ItemTransacaoAgrupado>,
+  ): Promise<ItemTransacaoAgrupado> {
+    return await this.itemTransacaoAgRepository.insertAsNew(dto);
   }
 
   public async save(

--- a/src/cron-jobs/cron-jobs.service.ts
+++ b/src/cron-jobs/cron-jobs.service.ts
@@ -96,10 +96,6 @@ export class CronJobsService implements OnModuleInit, OnModuleLoad {
   async onModuleLoad() {
     const THIS_CLASS_WITH_METHOD = 'CronJobsService.onModuleLoad';
 
-    // await this.saveTransacoesJae1();
-    // await this.sendRemessa();
-    // await this.saveTransacoesLancamento1();
-
     this.jobsConfig.push(
       {
         name: CrobJobsEnum.bulkSendInvites,

--- a/src/database/migrations/1718128591022-TransacaoViewValorPago.ts
+++ b/src/database/migrations/1718128591022-TransacaoViewValorPago.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class TransacaoViewValorPago1718128591022 implements MigrationInterface {
+    name = 'TransacaoViewValorPago1718128591022'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "transacao_view" ADD "valorPago" numeric`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "transacao_view" DROP COLUMN "valorPago"`);
+    }
+}

--- a/src/database/seeds/user/user-seed-data.service.ts
+++ b/src/database/seeds/user/user-seed-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { BQSInstances, BigqueryService } from 'src/bigquery/bigquery.service';
+import { BigquerySource, BigqueryService } from 'src/bigquery/bigquery.service';
 import { InviteStatus } from 'src/mail-history-statuses/entities/mail-history-status.entity';
 import { InviteStatusEnum } from 'src/mail-history-statuses/mail-history-status.enum';
 import { Role } from 'src/roles/entities/role.entity';
@@ -28,7 +28,7 @@ export class UserSeedDataService {
       if (this.cpfSamples.length === 0) {
         this.cpfSamples = (
           await this.bigqueryService.query(
-            BQSInstances.smtr,
+            BigquerySource.smtr,
             `
 SELECT
   DISTINCT o.documento,
@@ -43,7 +43,7 @@ LIMIT 5
       if (this.cnpjSamples.length === 0) {
         this.cnpjSamples = (
           await this.bigqueryService.query(
-            BQSInstances.smtr,
+            BigquerySource.smtr,
             `
 SELECT
   DISTINCT c.cnpj,

--- a/src/ticket-revenues/dtos/ticket-revenue.dto.ts
+++ b/src/ticket-revenues/dtos/ticket-revenue.dto.ts
@@ -1,7 +1,7 @@
 // @Exclude({ toPlainOnly: true })
 
-import { Exclude } from 'class-transformer';
 import { ArquivoPublicacao } from 'src/cnab/entity/arquivo-publicacao.entity';
+import { SetValueIf } from 'src/utils/decorators/set-value-if.decorator';
 
 /**
  * Internal representation of `IBqApiTicketRevenues`
@@ -223,8 +223,10 @@ export class TicketRevenueDTO {
    */
   transactionValue: number | null;
 
-  @Exclude()
-  /** Valor efetivado */
+  /** Valor a ser pago - valor líquido calculado
+   * Não significa que foi pago
+   */
+  @SetValueIf((o) => !o.isPago, 0)
   paidValue: number;
 
   /**

--- a/src/ticket-revenues/ticket-revenues-repository.ts
+++ b/src/ticket-revenues/ticket-revenues-repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { endOfDay, isToday, startOfDay } from 'date-fns';
-import { BQSInstances, BigqueryService } from 'src/bigquery/bigquery.service';
+import { BigquerySource, BigqueryService } from 'src/bigquery/bigquery.service';
 import { appSettings } from 'src/settings/app.settings';
 import { BigqueryEnvironment } from 'src/settings/enums/bigquery-env.enum';
 import { SettingsService } from 'src/settings/settings.service';
@@ -110,7 +110,7 @@ export class TicketRevenuesRepositoryService {
       (qArgs?.limit !== undefined ? `\nLIMIT ${qArgs.limit + 1}` : '') +
       (qArgs?.offset !== undefined ? `\nOFFSET ${qArgs.offset}` : '');
     const queryResult = await this.bigqueryService.query(
-      BQSInstances.smtr,
+      BigquerySource.smtr,
       query,
     );
 

--- a/src/ticket-revenues/ticket-revenues.service.ts
+++ b/src/ticket-revenues/ticket-revenues.service.ts
@@ -121,19 +121,7 @@ export class TicketRevenuesService {
       { cpfCnpj: user.getCpfCnpj(), startDate, endDate },
     );
 
-    const publicacaoIdsAux: number[] = [];
-    const paidSum = ticketRevenuesResponse.reduce((s, i) => {
-      const publicacaoId = i.arquivoPublicacao?.id;
-      if (!publicacaoId) {
-        return s;
-      }
-      if (publicacaoId && publicacaoIdsAux.includes(publicacaoId)) {
-        return s;
-      } else {
-        publicacaoIdsAux.push(publicacaoId);
-        return s + (i.arquivoPublicacao?.valorRealEfetivado || 0);
-      }
-    }, 0);
+    const paidSum = ticketRevenuesResponse.reduce((s, i) => s + i.paidValue, 0);
 
     if (ticketRevenuesResponse.length === 0) {
       return {

--- a/src/ticket-revenues/utils/ticket-revenues-groups.utils.ts
+++ b/src/ticket-revenues/utils/ticket-revenues-groups.utils.ts
@@ -2,8 +2,6 @@ import { DetalheA } from 'src/cnab/entity/pagamento/detalhe-a.entity';
 import { ITicketRevenue } from '../interfaces/ticket-revenue.interface';
 import { ITicketRevenuesGroup } from '../interfaces/ticket-revenues-group.interface';
 import { ITRCounts } from '../interfaces/tr-counts.interface';
-import { getNthWeek } from 'src/utils/date-utils';
-import { WeekdayEnum } from 'src/utils/enums/weekday.enum';
 
 const COUNTS_KEYS = [
   'transportTypeCounts',
@@ -76,12 +74,7 @@ export function appendItem(
     const value = group.transactionValueSum + newItem.transactionValue;
     group.transactionValueSum = Number(value.toFixed(2));
   }
-  const nthWeek = getNthWeek(new Date(newItem.date), WeekdayEnum._4_THURSDAY);
-  if (newItem.paidValue && !group.aux_nthWeeks.includes(nthWeek)) {
-    const value = group.paidValueSum + newItem.paidValue;
-    group.paidValueSum = Number(value.toFixed(2));
-    group.aux_nthWeeks.push(nthWeek);
-  }
+  group.paidValueSum += newItem.paidValue;
   const foundDetalhesA = detalhesA.filter(
     (i) =>
       i.itemTransacaoAgrupado.id ===

--- a/src/transacao-bq/transacao-view.entity.ts
+++ b/src/transacao-bq/transacao-view.entity.ts
@@ -14,6 +14,13 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+/**
+ * Unique: [datetimeTransacao, datetimeProcessamento]
+ */
+// @Unique('UQ_TransacaoView_datetimeTransacao_datetimeProcessamento', [
+//   'datetimeTransacao',
+//   'datetimeProcessamento',
+// ])
 @Entity()
 export class TransacaoView {
   constructor(transacao?: DeepPartial<TransacaoView>) {
@@ -71,6 +78,9 @@ export class TransacaoView {
   @Column({ type: 'numeric' })
   valorTransacao: number;
 
+  @Column({ type: 'numeric', nullable: true })
+  valorPago: number | null;
+
   @Column({ type: String, nullable: true })
   operadoraCpfCnpj: string | null;
 
@@ -92,6 +102,7 @@ export class TransacaoView {
   @AfterLoad()
   setReadValues() {
     this.valorTransacao = Number(this.valorTransacao);
+    this.valorPago = Number(this.valorPago);
   }
 
   public static newFromBigquery(bq: BigqueryTransacao) {
@@ -109,6 +120,7 @@ export class TransacaoView {
       tipoPagamento: bq.tipo_pagamento,
       tipoTransacao: bq.tipo_transacao,
       valorTransacao: bq.valor_transacao,
+      valorPago: bq.valor_pagamento,
       operadoraCpfCnpj: bq.operadoraCpfCnpj,
       consorcioCnpj: bq.consorcioCnpj,
     });
@@ -133,7 +145,7 @@ export class TransacaoView {
       transactionLat: null,
       transactionLon: null,
       transactionType: this.tipoTransacao,
-      paidValue: this.arquivoPublicacao?.valorRealEfetivado || 0,
+      paidValue: this.valorPago || 0,
       transactionValue: this.valorTransacao,
       transportIntegrationType: null,
       transportType: null,
@@ -141,5 +153,30 @@ export class TransacaoView {
       vehicleService: null,
       arquivoPublicacao: this.arquivoPublicacao || undefined,
     });
+  }
+
+  getProperties() {
+    return {
+      id: this.id,
+      datetimeTransacao: this.datetimeTransacao,
+      datetimeProcessamento: this.datetimeProcessamento,
+      datetimeCaptura: this.datetimeCaptura,
+      modo: this.modo,
+      idConsorcio: this.idConsorcio,
+      nomeConsorcio: this.nomeConsorcio,
+      idOperadora: this.idOperadora,
+      nomeOperadora: this.nomeOperadora,
+      idTransacao: this.idTransacao,
+      tipoPagamento: this.tipoPagamento,
+      tipoTransacao: this.tipoTransacao,
+      tipoGratuidade: this.tipoGratuidade,
+      valorTransacao: this.valorTransacao,
+      valorPago: this.valorPago,
+      operadoraCpfCnpj: this.operadoraCpfCnpj,
+      consorcioCnpj: this.consorcioCnpj,
+      arquivoPublicacao: this.arquivoPublicacao,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
   }
 }

--- a/src/transacao-bq/transacao-view.repository.ts
+++ b/src/transacao-bq/transacao-view.repository.ts
@@ -1,16 +1,36 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeepPartial, FindManyOptions, Repository } from 'typeorm';
+import { EntityCondition } from 'src/utils/types/entity-condition.type';
+import {
+  DataSource,
+  DeepPartial,
+  FindManyOptions,
+  In,
+  Repository,
+} from 'typeorm';
 import { UpsertOptions } from 'typeorm/repository/UpsertOptions';
 import { TransacaoView } from './transacao-view.entity';
-import { EntityCondition } from 'src/utils/types/entity-condition.type';
+import { CustomLogger } from 'src/utils/custom-logger';
 
 @Injectable()
 export class TransacaoViewRepository {
+  private logger = new CustomLogger(TransacaoView.name, {
+    timestamp: true,
+  });
+
   constructor(
+    private dataSource: DataSource,
     @InjectRepository(TransacaoView)
     private transacaoViewRepository: Repository<TransacaoView>,
   ) {}
+
+  async getMaxId(): Promise<number> {
+    const maxId = await this.transacaoViewRepository
+      .createQueryBuilder('t')
+      .select('MAX(t.id)', 'max')
+      .getRawOne();
+    return maxId.max;
+  }
 
   async count(fields?: EntityCondition<TransacaoView>) {
     if (fields) {
@@ -24,11 +44,21 @@ export class TransacaoViewRepository {
     return this.transacaoViewRepository.save(dto);
   }
 
-  public async upsert(
+  public async upsertById(
     dtos: DeepPartial<TransacaoView>[],
     conditions: UpsertOptions<TransacaoView>,
   ) {
     return await this.transacaoViewRepository.upsert(dtos, conditions);
+  }
+
+  public async insertByDatetime(dtos: DeepPartial<TransacaoView>[]) {
+    return await this.transacaoViewRepository
+      .createQueryBuilder()
+      .insert()
+      .into(TransacaoView)
+      .values(dtos)
+      .orIgnore()
+      .execute();
   }
 
   public async getOne(
@@ -43,6 +73,22 @@ export class TransacaoViewRepository {
     return await this.transacaoViewRepository.find(options);
   }
 
+  public async findExisting(
+    dtos: DeepPartial<TransacaoView>[],
+    skip?: number,
+    take?: number,
+  ) {
+    const transacoes = await this.transacaoViewRepository.find({
+      where: {
+        idTransacao: In(dtos.map((i) => i.idTransacao)),
+      },
+      loadEagerRelations: false,
+      skip,
+      take,
+    });
+    return transacoes;
+  }
+
   public async findOne(
     options: FindManyOptions<TransacaoView>,
   ): Promise<TransacaoView | null> {
@@ -51,12 +97,21 @@ export class TransacaoViewRepository {
   }
 
   async updateMany(ids: number[], dto: DeepPartial<TransacaoView>) {
-    await this.transacaoViewRepository
-      .createQueryBuilder('t')
-      .update()
-      .set(dto)
-      .whereInIds(ids)
-      .execute();
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    try {
+      await queryRunner.startTransaction();
+      await queryRunner.manager.update(TransacaoView, { id: In(ids) }, dto);
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error(
+        `Falha ao atualizar${ids.length} TransacaoViews - ${error?.message}`,
+        error?.stack,
+      );
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   createQueryBuilder = this.transacaoViewRepository.createQueryBuilder;

--- a/src/transacao-bq/transacao-view.service.ts
+++ b/src/transacao-bq/transacao-view.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { getChunks, groupBy } from 'src/utils/array-utils';
 import { CustomLogger } from 'src/utils/custom-logger';
 import { EntityCondition } from 'src/utils/types/entity-condition.type';
-import { DeepPartial, FindManyOptions, In } from 'typeorm';
+import { DataSource, DeepPartial, FindManyOptions, In } from 'typeorm';
 import { TransacaoView } from './transacao-view.entity';
 import { TransacaoViewRepository } from './transacao-view.repository';
 
@@ -11,7 +12,10 @@ export class TransacaoViewService {
     timestamp: true,
   });
 
-  constructor(private transacaoViewRepository: TransacaoViewRepository) {}
+  constructor(
+    private transacaoViewRepository: TransacaoViewRepository,
+    private dataSource: DataSource,
+  ) {}
 
   async count(fields?: EntityCondition<TransacaoView>) {
     return await this.transacaoViewRepository.count(fields);
@@ -37,34 +41,126 @@ export class TransacaoViewService {
   getOne = this.transacaoViewRepository.getOne;
 
   async upsertId(dtos: TransacaoView[]) {
-    return await this.transacaoViewRepository.upsert(dtos, {
+    return await this.transacaoViewRepository.upsertById(dtos, {
       conflictPaths: {
         id: true,
       },
     });
   }
 
-  async updateMany(ids: number[], update: DeepPartial<TransacaoView>) {
-    return await this.transacaoViewRepository.updateMany(ids, update);
+  async updateMany(ids: number[], dto: DeepPartial<TransacaoView>) {
+    await this.transacaoViewRepository.updateMany(ids, dto);
   }
 
-  async insertMany(dtos: TransacaoView[]) {
-    const _dtos = await this.ignoreExisting(structuredClone(dtos));
-    const chunks: TransacaoView[][] = [];
-    while (_dtos.length) {
-      chunks.push(_dtos.splice(0, 50));
-    }
+  /**
+   * Tarefas:
+   * 1. Faz paginação de cada i
+   */
+  async findExisting(
+    transacoes: DeepPartial<TransacaoView>[],
+    callback: (existing: TransacaoView[]) => void,
+  ) {
+    // const len = await this.transacaoViewRepository.count();
+    // for (let i = 0; i < len; i += chunkSize) {
+    const existing = await this.transacaoViewRepository.findExisting(
+      transacoes ,
+    );
+    callback(existing);
+    // }
+  }
 
-    let count = 1;
-    for (const chunk of chunks) {
-      this.logger.log(`Inserindo TransacaoViews ${count}/${chunks.length}`);
-      await this.transacaoViewRepository.upsert(chunk, {
-        conflictPaths: {
-          id: true,
-        },
-      });
-      count += 1;
+  /**
+   * Tarefas:
+   * 1. Atualizar separadamente os campos: valor_pago e tipo_transacao (smtr)
+   * 2. Para cada campo, agrupar pelo valor - para fazer um updateMany
+   * 3. Separar cada update em chunks para não sobrecarregar
+   */
+  async saveMany(
+    existings: TransacaoView[],
+    transacoes: DeepPartial<TransacaoView>[],
+  ) {
+    this.logger.log(
+      `Há Atualizando ou inserindo ${transacoes.length} ` +
+        `TransacaoVies, há ${existings.length} existentes...`,
+    );
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    try {
+      await queryRunner.startTransaction();
+      let index = 1;
+      let maxId = await this.transacaoViewRepository.getMaxId();
+      for (const item of transacoes) {
+        const existing = existings.filter(
+          (i) => i.idTransacao === item.idTransacao,
+        )[0] as TransacaoView | undefined;
+        if (existing) {
+          this.logger.debug(
+            `Atualizando item ${existing.id} - ${index}/${transacoes.length}`,
+          );
+          await queryRunner.manager.save(TransacaoView, {
+            id: existing.id,
+            ...item,
+          });
+        } else {
+          this.logger.debug(
+            `Inserindo novo item - ${index}/${transacoes.length}`,
+          );
+          item.id = ++maxId;
+          await queryRunner.manager.save(TransacaoView, item);
+        }
+        index++;
+      }
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error(
+        `Falha ao salvar ${transacoes.length} TransacaoViews - ${error?.message}`,
+        error?.stack,
+      );
+    } finally {
+      await queryRunner.release();
     }
+  }
+
+  async updateManyBy(
+    existing: DeepPartial<TransacaoView>[],
+    property: keyof TransacaoView,
+  ) {
+    const allProp = existing.filter((i) => i.id && i[property]);
+    const groupByProp = groupBy(allProp, property);
+    for (const prop of groupByProp) {
+      const chunks = getChunks(prop, 100);
+      for (const chunk of chunks) {
+        const ids = chunk.map((i) => i.id as number);
+        await this.transacaoViewRepository.updateMany(ids, {
+          [property]: chunk[0][property] as string,
+        });
+      }
+    }
+  }
+
+  async insertMany(dtos: DeepPartial<TransacaoView>[]) {
+    for (const item of dtos) {
+      await this.transacaoViewRepository.save(item);
+    }
+    // const _dtos = await this.ignoreExisting(structuredClone(dtos));
+    // const chunks: TransacaoView[][] = [];
+    // while (dtos.length) {
+    //   chunks.push(dtos.splice(0, 100));
+    // }
+
+    // let count = 1;
+    // for (const chunk of chunks) {
+    //   this.logger.log(`Inserindo TransacaoViews ${count}/${chunks.length}`);
+    //   await this.transacaoViewRepository.insertByDatetime(chunk);
+    //   // await this.transacaoViewRepository.upsert(chunk, {
+    //   //   conflictPaths: {
+    //   //     datetimeTransacao: true,
+    //   //     datetimeProcessamento: true,
+    //   //   },
+    //   // });
+    //   count += 1;
+    // }
   }
 
   async ignoreExisting(dtos: TransacaoView[]) {

--- a/src/utils/array-utils.ts
+++ b/src/utils/array-utils.ts
@@ -9,10 +9,12 @@ export function isArrayContainEqual(arr1: any[], arr2: any[]): boolean {
   return arr1_.length == arr2_.length && arr1_.every((u, i) => u === arr2_[i]);
 }
 
-export function groupArrayBy<T>(array: T[], property: keyof T): T[][] {
-  const uniqueValues = Array.from(new Set(array.map(obj => obj[property]))) as (string | number)[];
-  const groupedArray = uniqueValues.map(value =>
-    array.filter(obj => obj[property] === value)
+export function groupBy<T>(array: T[], property: keyof T): T[][] {
+  const uniqueValues = Array.from(
+    new Set(array.map((obj) => obj[property])),
+  ) as (string | number)[];
+  const groupedArray = uniqueValues.map((value) =>
+    array.filter((obj) => obj[property] === value),
   );
   return groupedArray;
 }
@@ -30,11 +32,14 @@ export function getFirstOfEach<T>(array: T[], property: keyof T): T[] {
   return Object.values(groupDict);
 }
 
-export function getUniqueFromArray<T>(items: T[], uniqueKeys: (keyof T)[]): T[] {
+export function getUniqueFromArray<T>(
+  items: T[],
+  uniqueKeys: (keyof T)[],
+): T[] {
   const uniqueItems: T[] = [];
   const keySet = new Set<string>();
   for (const item of items) {
-    const uniqueKeyId = uniqueKeys.map(key => String(item[key])).join('|');
+    const uniqueKeyId = uniqueKeys.map((key) => String(item[key])).join('|');
     // get only first unique item
     if (!keySet.has(uniqueKeyId)) {
       keySet.add(uniqueKeyId);
@@ -45,5 +50,26 @@ export function getUniqueFromArray<T>(items: T[], uniqueKeys: (keyof T)[]): T[] 
 }
 
 export function filterArrayInANotInB<T>(listA: T[], listB: T[]): T[] {
-  return listA.filter(itemA => !listB.includes(itemA));
+  return listA.filter((itemA) => !listB.includes(itemA));
+}
+
+export function getChunks<T>(array: T[], length: number) {
+  const buffer = structuredClone(array);
+  const chunks: T[][] = [];
+  while (buffer.length) {
+    chunks.push(buffer.splice(0, length));
+  }
+  return chunks;
+}
+
+export function forChunk<T>(
+  array: T[],
+  length: number,
+  callback: (chunk: T[]) => void,
+) {
+  const buffer = structuredClone(array);
+  while (buffer.length) {
+    const chunk = buffer.splice(0, length);
+    callback(chunk);
+  }
 }

--- a/src/utils/decorators/set-value-if.decorator.ts
+++ b/src/utils/decorators/set-value-if.decorator.ts
@@ -1,0 +1,9 @@
+import { Transform } from 'class-transformer';
+
+export function SetValueIf(predicate: (object: any) => boolean, newValue: any) {
+  return function (target: any, propertyKey: string) {
+    Transform(({ obj }) => (predicate(obj) ? newValue : obj[propertyKey]), {
+      toPlainOnly: true,
+    })(target, propertyKey);
+  };
+}

--- a/src/utils/validation-utils.ts
+++ b/src/utils/validation-utils.ts
@@ -45,3 +45,7 @@ export function getInvalidRows(errors: ValidationError[]): InvalidRows {
     return result;
   }, {});
 }
+
+export function hasValue(value: any) {
+  return value !== undefined && value !== null
+}


### PR DESCRIPTION
## Mudanças

- 🐞 fix: Estava gerando remessas agrupando erroneamente por idConsorcio, agora agrupamos por operadores for STPL, senão, por consórcios.
- 🐞 fix: bank-statements/me exibia o valor pago não zerado mesmo se ArquivoPublicacao.isPago = false
