### PR TITLE
Hotfix/transacao-tec

### DIFF
--- a/src/bigquery/repositories/bigquery-transacao.repository.ts
+++ b/src/bigquery/repositories/bigquery-transacao.repository.ts
@@ -24,6 +24,7 @@ export interface IBqFindTransacao {
   valor_pagamento?: number[] | null | ['>=' | '<=' | '>' | '<', number] | 'NOT NULL';
   id_transacao?: string[] | null;
   id_operadora?: string[];
+  nomeConsorcio?: { in?: string[], notIn?: string[]};
 }
 
 @Injectable()
@@ -78,7 +79,7 @@ export class BigqueryTransacaoRepository {
           t.valor_pagamento,
           t.versao AS bqDataVersion,
           t.consorcio,
-          t.operadora,
+          o.operadora_completo AS operadora,
           t.id_consorcio,
           t.id_operadora,
           o.documento AS operadoraCpfCnpj,
@@ -137,6 +138,12 @@ export class BigqueryTransacaoRepository {
     }
     if (args?.previousDaysOnly === true) {
       queryBuilder.pushAND('DATE(t.datetime_processamento) > DATE(t.datetime_transacao)');
+    }
+    if (args?.nomeConsorcio?.in?.length) {
+      queryBuilder.pushAND(`t.consorcio IN ('${args.nomeConsorcio.in.join("','")}')`);
+    }
+    if (args?.nomeConsorcio?.notIn?.length) {
+      queryBuilder.pushAND(`t.consorcio NOT IN ('${args.nomeConsorcio.notIn.join("','")}')`);
     }
     if (args?.valor_pagamento !== undefined) {
       const _value = args.valor_pagamento;

--- a/src/bigquery/services/bigquery-transacao.service.ts
+++ b/src/bigquery/services/bigquery-transacao.service.ts
@@ -14,11 +14,12 @@ export class BigqueryTransacaoService {
    *
    * @param [daysBack=0] Pega a semana atual ou N dias atrás.
    */
-  public async getFromWeek(dataOrdemInicial: Date, dataOrdemFinal: Date, daysBack = 0): Promise<BigqueryTransacao[]> {
+  public async getFromWeek(dataOrdemInicial: Date, dataOrdemFinal: Date, daysBack = 0, filter?: IBqFindTransacao): Promise<BigqueryTransacao[]> {
     const transacao = (
       await this.bigqueryTransacaoRepository.findMany({
         startDate: dataOrdemInicial,
         endDate: dataOrdemFinal,
+        ...(filter ? filter : {}),
       })
     ).map((i) => ({ ...i } as BigqueryTransacao));
     return transacao;

--- a/src/cnab/cnab-manutencao.controller.ts
+++ b/src/cnab/cnab-manutencao.controller.ts
@@ -220,7 +220,7 @@ export class CnabManutencaoController {
   @ApiBearerAuth()
   @ApiQuery({ name: 'dataOrdemInicial', type: Date, required: true, description: 'Data da Ordem de Pagamento Inicial' })
   @ApiQuery({ name: 'dataOrdemFinal', type: Date, required: true, description: 'Data da Ordem de Pagamento Final' })
-  @ApiQuery({ name: 'consorcio', type: String, required: false, description: ApiDescription({ _: 'Nome do consorcio - salvar transações', default: 'Todos' }), example: 'Todos / Van / Empresa /Nome Consorcio' })
+  @ApiQuery({ name: 'consorcio', type: String, required: false, description: ApiDescription({ _: 'Nome do consorcio - salvar transações', default: 'Todos' }), example: 'Todos / Van / Empresa / Nome Consorcio' })
   @ApiQuery({ name: 'idTransacao', type: String, required: false, description: 'Lista de idTransacao para atualizar' })
   async getUpdateTransacaoViewBigquery(
     @Query('dataOrdemInicial', new ParseDatePipe({ transform: true })) dataOrdemInicial: any, //

--- a/src/cnab/cnab.service.ts
+++ b/src/cnab/cnab.service.ts
@@ -398,9 +398,9 @@ export class CnabService {
     const transacoesBq = await this.bigqueryTransacaoService.getFromWeek(startOfDay(dataOrdemIncial), endOfDay(dataOrdemFinal), daysBack);
     let trs = transacoesBq;
     if (consorcio === 'Van') {
-      trs = transacoesBq.filter((tr) => tr.consorcio === 'STPC' || tr.consorcio === 'STPL');
+      trs = transacoesBq.filter((tr) => ['STPC','STPL','TEC'].includes(tr.consorcio));
     } else if (consorcio == 'Empresa') {
-      trs = transacoesBq.filter((tr) => tr.consorcio !== 'STPC' && tr.consorcio !== 'STPL');
+      trs = transacoesBq.filter((tr) => !['STPC','STPL','TEC'].includes(tr.consorcio));
     }
     return trs;
   }

--- a/src/cnab/cnab.service.ts
+++ b/src/cnab/cnab.service.ts
@@ -395,14 +395,16 @@ export class CnabService {
   }
 
   async findBigqueryTransacao(dataOrdemIncial: Date, dataOrdemFinal: Date, daysBack = 0, consorcio: string): Promise<BigqueryTransacao[]> {
-    const transacoesBq = await this.bigqueryTransacaoService.getFromWeek(startOfDay(dataOrdemIncial), endOfDay(dataOrdemFinal), daysBack);
-    let trs = transacoesBq;
+    const nomeConsorcio: { in: string[], notIn: string[] } = {in: [], notIn: [] };
     if (consorcio === 'Van') {
-      trs = transacoesBq.filter((tr) => ['STPC','STPL','TEC'].includes(tr.consorcio));
+      nomeConsorcio.in = ['STPC', 'STPL', 'TEC'];
     } else if (consorcio == 'Empresa') {
-      trs = transacoesBq.filter((tr) => !['STPC','STPL','TEC'].includes(tr.consorcio));
+      nomeConsorcio.notIn = ['STPC', 'STPL', 'TEC'];
+    } else if (consorcio != 'Todos') {
+      nomeConsorcio.in = consorcio.split(',');
     }
-    return trs;
+    const transacoesBq = await this.bigqueryTransacaoService.getFromWeek(startOfDay(dataOrdemIncial), endOfDay(dataOrdemFinal), daysBack, { nomeConsorcio });
+    return transacoesBq;
   }
 
   // #region saveOrdens


### PR DESCRIPTION
# Correções

- fix: Incluir TEC ao pesquisar por Van (vanzeiro)
- fix: Filtrar Empresa, Van etc direto no Bigquery ao invés de buscar todo mundo e filtrar no backend - Melhor desempenho
- fix: É possível também atualizar TransacaoView filtrando pelo nome do consórcio (e.g. `TEC` ou `TEC,STPC`). Usado no endpoint manutenção para atualizar os TEC de Outubro