### PR TITLE
Consertar endpoint dos dias anteriores

### DIFF
--- a/src/cnab/novo-remessa/controller/ordem-pagamento.controller.ts
+++ b/src/cnab/novo-remessa/controller/ordem-pagamento.controller.ts
@@ -126,7 +126,7 @@ export class OrdemPagamentoController {
     return this.bigqueryTransacaoService.findManyByOrdemPagamentoIdInGroupedByTipoTransacao(ordemPagamentoIds, user?.cpfCnpj, request);
   }
 
-  @Get('transacoes-dias-anteriores')
+  @Get('transacoes-dias-anteriores/:ordemPagamentoAgrupadoId')
   @UseGuards(AuthGuard('jwt'))
   @SerializeOptions({ groups: ['me'] })
   @ApiBearerAuth()
@@ -134,13 +134,14 @@ export class OrdemPagamentoController {
   @ApiQuery(CommonApiParams.userId)
   async getTransacoesDiasAnteriores(
     @Request() request: IRequest, //
+    @Param('ordemPagamentoAgrupadoId', new ParseNumberPipe({ min: 1, optional: false })) ordemPagamentoAgrupadoId: number,
     @Query('userId', new ParseNumberPipe({ min: 1, optional: false })) userId: number | null,
-  ): Promise<OrdemPagamentoPendenteNuncaRemetidasDto[]> {
+  ): Promise<OrdemPagamentoSemanalDto[]> {
     this.logger.log(getRequestLog(request));
     const isUserIdNumber = userId !== null && !isNaN(Number(userId));
     const userIdNum = isUserIdNumber ? Number(userId) : request.user.id;
     canProceed(request, Number(userId));
-    return this.ordemPagamentoService.findOrdensPagamentosPendentesQueNuncaForamRemetidas(userIdNum);
+    return this.ordemPagamentoService.findOrdensPagamentoDiasAnterioresByOrdemPagamentoAgrupadoId(ordemPagamentoAgrupadoId, userIdNum);
   }
 
 }

--- a/src/cnab/novo-remessa/repository/ordem-pagamento.repository.ts
+++ b/src/cnab/novo-remessa/repository/ordem-pagamento.repository.ts
@@ -254,13 +254,39 @@ export class OrdemPagamentoRepository {
           AND opa.id = $1
           AND o."dataCaptura" IS NOT NULL
           AND o."userId" = $2
-        ORDER BY o."dataOrdem"
+          AND date_trunc('day', o."dataOrdem") BETWEEN date_trunc('day', "dataPagamento") - INTERVAL '7 days' AND date_trunc('day', "dataPagamento") - INTERVAL '1 day'
+        ORDER BY o."dataOrdem" desc
     `;
 
     const result = await this.ordemPagamentoRepository.query(query, [ordemPagamentoAgrupadoId, userId]);
     return result.map((row: any) => {
       const ordemPagamento = new OrdemPagamentoSemanalDto();
       ordemPagamento.ordemId = row.id;
+      ordemPagamento.dataOrdem = row.dataOrdem;
+      ordemPagamento.valor = row.valor? parseFloat(row.valor): 0;
+      return ordemPagamento;
+    });
+  }
+
+  public async findOrdensPagamentoDiasAnterioresByOrdemPagamentoAgrupadoId(ordemPagamentoAgrupadoId: number, userId: number): Promise<OrdemPagamentoSemanalDto[]> {
+    const query = `
+        SELECT SUM(ROUND(valor, 2)) valor,
+               o."dataOrdem"
+        FROM ordem_pagamento o
+        INNER JOIN ordem_pagamento_agrupado opa
+        ON o."ordemPagamentoAgrupadoId" = opa.id
+        WHERE 1 = 1
+          AND opa.id = $1
+          AND o."dataCaptura" IS NOT NULL
+          AND o."userId" = $2
+          AND date_trunc('day', o."dataOrdem") < date_trunc('day', "dataPagamento") - INTERVAL '7 days'
+        GROUP BY o."dataOrdem"
+        ORDER BY o."dataOrdem" desc
+    `;
+
+    const result = await this.ordemPagamentoRepository.query(query, [ordemPagamentoAgrupadoId, userId]);
+    return result.map((row: any) => {
+      const ordemPagamento = new OrdemPagamentoSemanalDto();
       ordemPagamento.dataOrdem = row.dataOrdem;
       ordemPagamento.valor = row.valor? parseFloat(row.valor): 0;
       return ordemPagamento;

--- a/src/cnab/novo-remessa/service/ordem-pagamento.service.ts
+++ b/src/cnab/novo-remessa/service/ordem-pagamento.service.ts
@@ -92,4 +92,8 @@ export class OrdemPagamentoService {
     return await this.ordemPagamentoRepository.findOrdensPagamentosPendentesQueNuncaForamRemetidas(userId);
   }
 
+  async findOrdensPagamentoDiasAnterioresByOrdemPagamentoAgrupadoId(ordemPagamentoAgrupadoId: number, userId: number): Promise<OrdemPagamentoSemanalDto[]> {
+    return await this.ordemPagamentoRepository.findOrdensPagamentoDiasAnterioresByOrdemPagamentoAgrupadoId(ordemPagamentoAgrupadoId, userId);
+  }
+
 }


### PR DESCRIPTION
- Recebe o ID das ordens agrupadas no endpoint dos dias anteriores
- Garante que ordens antigas não apareçam no endpoint do semanal
- Mostra ordens antigas que foram agrupadas para pagamento