### PR TITLE
Expose role-aware conclude-registration metadata

### DIFF
--- a/src/auth-licensee/auth-licensee.service.spec.ts
+++ b/src/auth-licensee/auth-licensee.service.spec.ts
@@ -126,6 +126,7 @@ describe('AuthLicenseeService', () => {
         email: 'agent@example.com',
         fullName: 'Agent Name',
         permitCode: 'permit-1',
+        cpfCnpj: '12345678901',
       });
       user.role = new Role(RoleEnum.agentes);
       const mailHistory = {
@@ -144,6 +145,7 @@ describe('AuthLicenseeService', () => {
         fullName: 'Agent Name',
         permitCode: 'permit-1',
         email: 'agent@example.com',
+        cpfCnpj: '12345678901',
         hash: 'hash_2',
         inviteStatus: mailHistory.inviteStatus,
         roleId: RoleEnum.agentes,

--- a/src/auth-licensee/auth-licensee.service.ts
+++ b/src/auth-licensee/auth-licensee.service.ts
@@ -192,6 +192,7 @@ export class AuthLicenseeService {
       fullName: user.fullName as string,
       permitCode: user.permitCode,
       email: user.email,
+      cpfCnpj: user.cpfCnpj,
       hash: invite.hash,
       inviteStatus: invite.inviteStatus,
       roleId: user.role?.id ?? null,

--- a/src/auth-licensee/interfaces/al-invite-profile.interface.ts
+++ b/src/auth-licensee/interfaces/al-invite-profile.interface.ts
@@ -8,6 +8,7 @@ export interface IALInviteProfile {
   permitCode: string;
   email: string;
   fullName: string;
+  cpfCnpj: string | null | undefined;
   inviteStatus: InviteStatus;
   roleId: number | null;
   redirectTo: string;


### PR DESCRIPTION
## Summary
- return role-aware redirect metadata from conclude-registration invite and register flows
- include cpfCnpj in the invite profile response
- add service coverage for role-aware invite/register responses

## Validation
- npx jest auth-licensee.service.spec.ts --runInBand with a temporary local Jest config